### PR TITLE
[feat] CourseGrade API 완성

### DIFF
--- a/src/application/course_grades/model.rs
+++ b/src/application/course_grades/model.rs
@@ -13,6 +13,18 @@ pub struct GradeSummary {
     avg: f32,
     pf_earned_credits: f32
 }
+impl GradeSummary {
+    pub(crate) fn new(attempted_credits: f32, earned_credits: f32, gpa: f32, cgpa: f32, avg: f32, pf_earned_credits: f32) -> GradeSummary {
+        GradeSummary {
+            attempted_credits,
+            earned_credits,
+            gpa,
+            cgpa,
+            avg,
+            pf_earned_credits
+        }
+    }
+}
 
 
 

--- a/src/application/course_grades/model.rs
+++ b/src/application/course_grades/model.rs
@@ -2,10 +2,24 @@ use std::{collections::HashMap, num::ParseIntError, str::FromStr};
 
 use getset::Getters;
 
-#[derive(Debug, Getters)]
+#[derive(Getters, Debug)]
 #[allow(unused)]
 #[get = "pub"]
 pub struct GradeSummary {
+    attempted_credits: f32,
+    earned_credits: f32,
+    gpa: f32,
+    cgpa: f32,
+    avg: f32,
+    pf_earned_credits: f32
+}
+
+
+
+#[derive(Debug, Getters)]
+#[allow(unused)]
+#[get = "pub"]
+pub struct SemesterGrade {
     year: u32,
     semester: String,
     attempt_credits: f32,
@@ -21,7 +35,7 @@ pub struct GradeSummary {
     flunked: bool,
 }
 
-impl GradeSummary {
+impl SemesterGrade {
     pub fn new(
         year: u32,
         semester: String,
@@ -36,8 +50,8 @@ impl GradeSummary {
         academic_probation: bool,
         consult: bool,
         flunked: bool,
-    ) -> GradeSummary {
-        GradeSummary {
+    ) -> Self {
+        Self {
             year,
             semester,
             attempt_credits,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -93,9 +93,11 @@ impl<'a> USaintApplication {
     }
 }
 
-pub mod course_grades;
+mod course_grades;
 mod course_schedule;
 mod student_information;
+
+pub use self::course_grades::CourseGrades;
 
 #[cfg(test)]
 mod test {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,7 +80,7 @@ pub async fn obtain_ssu_sso_token(id: &str, password: &str) -> Result<String> {
         .await?;
     let cookie_token = res
         .cookies()
-        .find(|cookie| cookie.name() == "sToken")
+        .find(|cookie| cookie.name() == "sToken" && !cookie.value().is_empty())
         .ok_or(SsuSsoError::CantFindToken)?;
     Ok(cookie_token.value().to_string())
 }

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use std::sync::{Arc, OnceLock};
 
 use dotenv::dotenv;
-use rusaint::{application::course_grades::CourseGrades, session::USaintSession};
+use rusaint::{application::CourseGrades, session::USaintSession};
 use serial_test::serial;
 
 static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -25,11 +25,13 @@ async fn get_session() -> Result<Arc<USaintSession>> {
 
 #[tokio::test]
 #[serial]
-async fn summary() {
+async fn summaries() {
     let session = get_session().await.unwrap();
     let app = CourseGrades::new(session).await.unwrap();
-    let summary = app.summary().unwrap();
-    println!("{:?}", summary);
+    let recorded_summary = app.recorded_summary().unwrap();
+    println!("Recorded: {:?}", recorded_summary);
+    let certificated_summary = app.certificated_summary().unwrap();
+    println!("Certificated: {:?}", certificated_summary);
 }
 #[tokio::test]
 #[serial]
@@ -46,7 +48,12 @@ async fn semesters() {
 async fn classes_with_detail() {
     let session = get_session().await.unwrap();
     let mut app = CourseGrades::new(session).await.unwrap();
-    let detail = app.classes("2022", "092", true).await.unwrap();
+    let details = app.classes("2022", "092", true).await.unwrap();
+    println!("{:?}", details);
+    assert!(!details.is_empty());
+    println!("Try to obtain class's detail");
+    let detail_code = details.iter().find(|grade| grade.detail().is_some()).unwrap();
+    let detail = app.class_detail("2022", "092", detail_code.code()).await.unwrap();
     println!("{:?}", detail);
     assert!(!detail.is_empty());
 }

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -22,22 +22,31 @@ async fn get_session() -> Result<Arc<USaintSession>> {
             .ok_or(Error::msg("Session is not initsiated"))
     }
 }
+
 #[tokio::test]
 #[serial]
-async fn read_grades() {
+async fn summary() {
     let session = get_session().await.unwrap();
     let app = CourseGrades::new(session).await.unwrap();
-    let summary = app.grade_summary().unwrap();
+    let summary = app.summary().unwrap();
     println!("{:?}", summary);
-    assert!(!summary.is_empty());
+}
+#[tokio::test]
+#[serial]
+async fn semesters() {
+    let session = get_session().await.unwrap();
+    let app = CourseGrades::new(session).await.unwrap();
+    let semesters = app.semesters().unwrap();
+    println!("{:?}", semesters);
+    assert!(!semesters.is_empty());
 }
 
 #[tokio::test]
 #[serial]
-async fn grade_detail() {
+async fn classes_with_detail() {
     let session = get_session().await.unwrap();
     let mut app = CourseGrades::new(session).await.unwrap();
-    let detail = app.grade_detail("2022", "092", true).await.unwrap();
+    let detail = app.classes("2022", "092", true).await.unwrap();
     println!("{:?}", detail);
     assert!(!detail.is_empty());
 }


### PR DESCRIPTION
# What’s in this Pull Request
- `application::course_grades::CourseGrades` 를 `application::CourseGrades`로 Re-export하고 기존 모듈은 숨겼습니다.
- 성적 열람 관련 API의 명칭을 간단화했습니다.
  - `grade_summary()` -> `semesters()`
  - `grade_detail()` -> `classes()`
- 전체 합산 성적(학적부, 증명)을 열람하는 함수(`recorded_summary()`, `certificated_summary()`)를 추가하였습니다.
- 수업의 상세 성적만을 열람할 수 있는 함수 `class_detail()`을 추가했습니다.