### PR TITLE
[refactor] SemesterType 추가

### DIFF
--- a/src/application/course_schedule.rs
+++ b/src/application/course_schedule.rs
@@ -3,6 +3,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::{
     define_elements,
+    model::SemesterType,
     webdynpro::element::{
         action::button::Button, complex::sap_table::SapTable, layout::tab_strip::TabStrip,
         selection::combo_box::ComboBox,
@@ -45,14 +46,27 @@ impl<'a> CourseSchedule {
         ))
     }
 
-    pub async fn select_period(&mut self, year: u32, period: &str) -> Result<()> {
+    fn semester_to_key(period: SemesterType) -> &'static str {
+        match period {
+            SemesterType
+    ::One => "090",
+            SemesterType
+    ::Summer => "091",
+            SemesterType
+    ::Two => "092",
+            SemesterType
+    ::Winter => "0923",
+        }
+    }
+
+    pub async fn select_period(&mut self, year: &str, period: SemesterType) -> Result<()> {
         let events = {
             let body = self.body();
             let period_year = Self::PERIOD_YEAR.from_body(body)?;
             let period_id = Self::PERIOD_ID.from_body(body)?;
             vec![
-                period_year.select(year.to_string().as_str(), false)?,
-                period_id.select(period, false)?,
+                period_year.select(year, false)?,
+                period_id.select(Self::semester_to_key(period), false)?,
             ]
         };
         self.send_events(events).await
@@ -131,10 +145,10 @@ mod test {
                 for item in listbox.items() {
                     match item {
                         ListBoxItemWrapper::Item(item) => {
-                            println!("{:?}", item);
+                            println!("value: {:?}, key: {:?}", item.value1(), item.key());
                         }
                         ListBoxItemWrapper::ActionItem(item) => {
-                            println!("{:?}", item);
+                            println!("title: {:?}, text: {:?}", item.title(), item.text());
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod application;
+pub mod model;
 pub mod session;
 pub mod utils;
 pub mod webdynpro;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,6 @@
+pub enum SemesterType {
+    One,
+    Summer,
+    Two,
+    Winter,
+}

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use std::sync::{Arc, OnceLock};
 
 use dotenv::dotenv;
-use rusaint::{application::CourseGrades, session::USaintSession};
+use rusaint::{application::CourseGrades, model::SemesterType, session::USaintSession};
 use serial_test::serial;
 
 static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();
@@ -48,12 +48,18 @@ async fn semesters() {
 async fn classes_with_detail() {
     let session = get_session().await.unwrap();
     let mut app = CourseGrades::new(session).await.unwrap();
-    let details = app.classes("2022", "092", true).await.unwrap();
+    let details = app.classes("2022", SemesterType::Two, true).await.unwrap();
     println!("{:?}", details);
     assert!(!details.is_empty());
     println!("Try to obtain class's detail");
-    let detail_code = details.iter().find(|grade| grade.detail().is_some()).unwrap();
-    let detail = app.class_detail("2022", "092", detail_code.code()).await.unwrap();
+    let detail_code = details
+        .iter()
+        .find(|grade| grade.detail().is_some())
+        .unwrap();
+    let detail = app
+        .class_detail("2022", SemesterType::Two, detail_code.code())
+        .await
+        .unwrap();
     println!("{:?}", detail);
     assert!(!detail.is_empty());
 }


### PR DESCRIPTION
# What’s in this pull request
- 학기를 데이터로 활용하는 함수를 실행할 때 이해하기 힘든 학기의 키 값(`090`, `091` 등) 대신 `SemesterType` enum을 이용하여 학기를 선택할 수 있도록 하였습니다.
- 일부 학기 관련 함수에서 `Period` 대신 `Semester` 용어를 사용하도록 수정하였습니다.