### PR TITLE
[refactor] Error 처리 재작성

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ scraper = "0.17.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1.9.5"
-anyhow = "1.0.75"
 getset = "0.1.2"
 custom_debug_derive = "0.5.1"
 
@@ -30,5 +29,6 @@ custom_debug_derive = "0.5.1"
 members = ["macro"]
 
 [dev-dependencies]
+anyhow = "1.0.75"
 dotenv = "0.15.0"
 serial_test = "*"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ _추가 예정_
 ## 예시
 
 ```rust
-use anyhow::Result;
 use rusaint::application::course_grades::{CourseGrades, data::GradeSummary};
 use rusaint::session::USaintSession;
 use futures::executor::block_on;

--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
@@ -19,7 +18,7 @@ use crate::{
             text::input_field::InputField,
             Element, ElementDef, ElementWrapper, SubElement,
         },
-        error::{BodyError, ElementError},
+        error::{BodyError, ElementError, WebDynproError},
         event::Event,
     },
 };
@@ -86,13 +85,13 @@ impl<'a> CourseGrades {
         GRADE_BY_CLASSES_TABLE: SapTable<'a> = "ZCMB3W0017.ID_0001:VIW_MAIN.TABLE_1",
     );
 
-    pub async fn new(session: Arc<USaintSession>) -> Result<CourseGrades> {
+    pub async fn new(session: Arc<USaintSession>) -> Result<CourseGrades, WebDynproError> {
         Ok(CourseGrades(
             USaintApplication::with_session(Self::APP_NAME, session).await?,
         ))
     }
 
-    async fn close_popups(&mut self) -> Result<()> {
+    async fn close_popups(&mut self) -> Result<(), WebDynproError> {
         fn make_close_event(app: &CourseGrades) -> Option<Event> {
             let body = app.body();
             let popup_selector =
@@ -123,7 +122,11 @@ impl<'a> CourseGrades {
         }
     }
 
-    async fn select_semester(&mut self, year: &str, semester: SemesterType) -> Result<()> {
+    async fn select_semester(
+        &mut self,
+        year: &str,
+        semester: SemesterType,
+    ) -> Result<(), WebDynproError> {
         let select = {
             let semester = Self::semester_to_key(semester);
             let mut vec = Vec::with_capacity(2);
@@ -135,7 +138,7 @@ impl<'a> CourseGrades {
             if (|| Some(semester_combobox.lsdata()?.key().as_ref()?.as_str()))() != Some(semester) {
                 vec.push(semester_combobox.select(semester, false)?);
             }
-            Result::<Vec<Event>>::Ok(vec)
+            Result::<Vec<Event>, WebDynproError>::Ok(vec)
         }?;
         if !select.is_empty() {
             self.send_events(select).await
@@ -162,14 +165,17 @@ impl<'a> CourseGrades {
         )
     }
 
-    fn value_as_f32(field: InputField<'_>) -> Result<f32> {
+    fn value_as_f32(field: InputField<'_>) -> Result<f32, WebDynproError> {
         let Some(value) = field.lsdata().and_then(|lsdata| lsdata.value().as_ref()) else {
             return Err(ElementError::NoSuchData { element: field.id().to_string(), field: "value1".to_string() })?;
         };
-        Ok(value.parse::<f32>()?)
+        Ok(value.parse::<f32>().or(Err(ElementError::InvalidContent {
+            element: field.id().to_string(),
+            content: "value1(not an correct f32)".to_string(),
+        }))?)
     }
 
-    pub fn recorded_summary(&self) -> Result<GradeSummary> {
+    pub fn recorded_summary(&self) -> Result<GradeSummary, WebDynproError> {
         let body = self.body();
         let attempted_credits = Self::value_as_f32(Self::ATTM_CRD1.from_body(body)?)?;
         let earned_credits = Self::value_as_f32(Self::EARN_CRD1.from_body(body)?)?;
@@ -187,7 +193,7 @@ impl<'a> CourseGrades {
         ))
     }
 
-    pub fn certificated_summary(&self) -> Result<GradeSummary> {
+    pub fn certificated_summary(&self) -> Result<GradeSummary, WebDynproError> {
         let body = self.body();
         let attempted_credits = Self::value_as_f32(Self::ATTM_CRD2.from_body(body)?)?;
         let earned_credits = Self::value_as_f32(Self::EARN_CRD2.from_body(body)?)?;
@@ -205,7 +211,7 @@ impl<'a> CourseGrades {
         ))
     }
 
-    pub fn semesters(&self) -> Result<Vec<SemesterGrade>> {
+    pub fn semesters(&self) -> Result<Vec<SemesterGrade>, WebDynproError> {
         fn parse_rank(value: String) -> Option<(u32, u32)> {
             let mut spl = value.split("/");
             let first: u32 = spl.next()?.parse().ok()?;
@@ -245,8 +251,8 @@ impl<'a> CourseGrades {
     async fn class_detail_in_popup<'f>(
         &mut self,
         open_button: ElementDef<'f, Button<'f>>,
-    ) -> Result<HashMap<String, f32>> {
-        fn parse_table_in_popup(body: &Body) -> Result<Vec<(String, f32)>> {
+    ) -> Result<HashMap<String, f32>, WebDynproError> {
+        fn parse_table_in_popup(body: &Body) -> Result<Vec<(String, f32)>, WebDynproError> {
             let table_inside_popup_selector =
                 scraper::Selector::parse(r#"[ct="PW"] [ct="ST"]"#).unwrap();
             let mut table_inside_popup = body.document().select(&table_inside_popup_selector);
@@ -265,8 +271,18 @@ impl<'a> CourseGrades {
                 content: "header and first row".to_string(),
             })?;
             zip.skip(4)
-                .map(|(key, val)| Ok((key, val.trim().parse::<f32>()?)))
-                .collect::<Result<Vec<(String, f32)>>>()
+                .map(|(key, val)| {
+                    Ok((
+                        key,
+                        val.trim()
+                            .parse::<f32>()
+                            .or(Err(ElementError::InvalidContent {
+                                element: table_elem.id().to_string(),
+                                content: "(not an correct f32)".to_string(),
+                            }))?,
+                    ))
+                })
+                .collect::<Result<Vec<(String, f32)>, WebDynproError>>()
         };
         let event = { open_button.from_body(self.body())?.press() }?;
         self.send_events(vec![event]).await?;
@@ -280,7 +296,7 @@ impl<'a> CourseGrades {
         year: &str,
         semester: SemesterType,
         code: &str,
-    ) -> Result<HashMap<String, f32>> {
+    ) -> Result<HashMap<String, f32>, WebDynproError> {
         self.select_semester(year, semester).await?;
         let table_elem = Self::GRADE_BY_CLASSES_TABLE.from_body(self.body())?;
         let Some(table) = table_elem.table()  else {
@@ -311,14 +327,17 @@ impl<'a> CourseGrades {
         year: &str,
         semester: SemesterType,
         include_details: bool,
-    ) -> Result<Vec<ClassGrade>> {
+    ) -> Result<Vec<ClassGrade>, WebDynproError> {
         self.close_popups().await?;
         self.select_semester(year, semester).await?;
         let class_grades: Vec<(Option<String>, Vec<String>)> = {
             let grade_table_elem = Self::GRADE_BY_CLASSES_TABLE.from_body(self.body())?;
             let iter = grade_table_elem
                 .table()
-                .ok_or(ElementError::NoSuchContent { element: grade_table_elem.id().to_string(), content: "Table body".to_string() })?
+                .ok_or(ElementError::NoSuchContent {
+                    element: grade_table_elem.id().to_string(),
+                    content: "Table body".to_string(),
+                })?
                 .iter()
                 .skip(1);
             iter.map(|row| {

--- a/src/application/student_information.rs
+++ b/src/application/student_information.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
 use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
 
-use crate::session::USaintSession;
+use crate::{session::USaintSession, webdynpro::error::WebDynproError};
 
 use super::USaintApplication;
 
@@ -27,7 +26,7 @@ impl<'a> DerefMut for StudentInformation {
 impl StudentInformation {
     const APP_NAME: &str = "ZCMW1001n";
 
-    pub async fn new(session: Arc<USaintSession>) -> Result<StudentInformation> {
+    pub async fn new(session: Arc<USaintSession>) -> Result<StudentInformation, WebDynproError> {
         Ok(StudentInformation(
             USaintApplication::with_session(Self::APP_NAME, session).await?,
         ))

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+use crate::webdynpro::error::WebDynproError;
+
+#[derive(Error, Debug)]
+pub enum RusaintError {
+    #[error("WebDynpro engine error: {0}")]
+    WebDynproError(#[from] WebDynproError),
+    #[error("Failed to login with ssu sso: {0}")]
+    SsoLoginError(#[from] SsuSsoError),
+}
+
+#[derive(Error, Debug)]
+pub enum SsuSsoError {
+    #[error("Request error: {0}")]
+    RequestError(#[from] reqwest::Error),
+    #[error("Can't load form data from page, is page changed?")]
+    CantLoadForm,
+    #[error("Token is not included in response.")]
+    CantFindToken,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod application;
+pub mod error;
 pub mod model;
 pub mod session;
 pub mod utils;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,6 +1,5 @@
 use std::{borrow::BorrowMut, ops::Deref};
 
-use anyhow::Result;
 use reqwest::{
     cookie::{CookieStore, Jar},
     header::{HeaderValue, COOKIE, HOST, SET_COOKIE},
@@ -9,7 +8,7 @@ use url::Url;
 
 use crate::{
     utils::{default_header, obtain_ssu_sso_token, DEFAULT_USER_AGENT},
-    webdynpro::error::ClientError,
+    webdynpro::error::{ClientError, WebDynproError}, error::RusaintError,
 };
 
 const SSU_USAINT_PORTAL_URL: &str = "https://saint.ssu.ac.kr/irj/portal";
@@ -41,7 +40,7 @@ impl USaintSession {
         USaintSession(Jar::default())
     }
 
-    pub async fn with_token(id: &str, token: &str) -> Result<USaintSession> {
+    pub async fn with_token(id: &str, token: &str) -> Result<USaintSession, ClientError> {
         let session_store = Self::anonymous();
         let client = reqwest::Client::builder()
             .user_agent(DEFAULT_USER_AGENT)
@@ -104,7 +103,9 @@ impl USaintSession {
         });
         session_store.set_cookies(&mut new_cookies, res.url());
         if let Some(sapsso_cookies) = session_store.cookies(res.url()) {
-            let str = sapsso_cookies.to_str()?;
+            let str = sapsso_cookies
+                .to_str()
+                .or(Err(ClientError::NoCookies(res.url().to_string())))?;
             if str.contains("MYSAPSSO2") {
                 Ok(session_store)
             } else {
@@ -115,9 +116,9 @@ impl USaintSession {
         }
     }
 
-    pub async fn with_password(id: &str, password: &str) -> Result<USaintSession> {
+    pub async fn with_password(id: &str, password: &str) -> Result<USaintSession, RusaintError> {
         let token = obtain_ssu_sso_token(id, password).await?;
-        Self::with_token(id, &token).await
+        Ok(Self::with_token(id, &token).await.or_else(|e| Err(WebDynproError::ClientError(e)))?)
     }
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -57,7 +57,7 @@ impl USaintSession {
         let waf = portal
             .cookies()
             .find(|cookie| cookie.name() == "WAF")
-            .ok_or(ClientError::NoCookie)?;
+            .ok_or(ClientError::NoSuchCookie("WAF".to_string()))?;
         let waf_cookie_str = format!("WAF={}; domain=saint.ssu.ac.kr; path=/;", waf.value());
         session_store.set_cookies(
             portal
@@ -108,10 +108,10 @@ impl USaintSession {
             if str.contains("MYSAPSSO2") {
                 Ok(session_store)
             } else {
-                Err(ClientError::NoCookie)?
+                Err(ClientError::NoSuchCookie("MYSAPSSO2".to_string()))?
             }
         } else {
-            Err(ClientError::NoCookie)?
+            Err(ClientError::NoCookies(res.url().to_string()))?
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use anyhow::Result;
 use reqwest::{
     cookie::Jar,
     header::{HeaderMap, ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, CONNECTION},
     Client,
 };
-use thiserror::Error;
+
+use crate::error::SsuSsoError;
 
 pub(crate) const DEFAULT_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
 const SMARTID_LOGIN_URL: &str = "https://smartid.ssu.ac.kr/Symtra_sso/smln.asp";
@@ -26,15 +26,8 @@ pub(crate) fn default_header() -> HeaderMap {
     headers.insert(CONNECTION, "keep-alive".parse().unwrap());
     headers
 }
-#[derive(Error, Debug)]
-pub enum SsuSsoError {
-    #[error("Can't load form data from page, is page changed?")]
-    CantLoadForm,
-    #[error("Token is not included in response.")]
-    CantFindToken,
-}
 
-pub async fn obtain_ssu_sso_token(id: &str, password: &str) -> Result<String> {
+pub async fn obtain_ssu_sso_token(id: &str, password: &str) -> Result<String, SsuSsoError> {
     let jar: Arc<Jar> = Arc::new(Jar::default());
     let client = Client::builder()
         .cookie_provider(jar)

--- a/src/webdynpro/application/client/body.rs
+++ b/src/webdynpro/application/client/body.rs
@@ -35,10 +35,10 @@ impl BodyUpdate {
         let updates = response_xml
             .root()
             .first_child()
-            .ok_or(BodyUpdateError::CannotFindNode("<updates>".to_string()))?;
+            .ok_or(BodyUpdateError::NoSuchNode("<updates>".to_string()))?;
         let update = updates
             .first_child()
-            .ok_or(BodyUpdateError::CannotFindNode(
+            .ok_or(BodyUpdateError::NoSuchNode(
                 "<full-update> or <delta-update>".to_string(),
             ))?;
         let update_type: Option<BodyUpdateType>;
@@ -46,17 +46,17 @@ impl BodyUpdate {
             let windowid =
                 update
                     .attribute("windowid")
-                    .ok_or(BodyUpdateError::CannotFindAttribute {
+                    .ok_or(BodyUpdateError::NoSuchAttribute {
                         node: "full-update".to_string(),
                         attribute: "windowid".to_string(),
                     })?;
             let content = update
                 .first_child()
-                .ok_or(BodyUpdateError::NoContent("full-update".to_string()))?;
+                .ok_or(BodyUpdateError::NoSuchContent("full-update".to_string()))?;
             let contentid =
                 content
                     .attribute("id")
-                    .ok_or(BodyUpdateError::CannotFindAttribute {
+                    .ok_or(BodyUpdateError::NoSuchAttribute {
                         node: "content-update".to_string(),
                         attribute: "id".to_string(),
                     })?;
@@ -70,14 +70,14 @@ impl BodyUpdate {
                 contentid.to_owned(),
                 content
                     .text()
-                    .ok_or(BodyUpdateError::NoContent("full-content".to_string()))?
+                    .ok_or(BodyUpdateError::NoSuchContent("full-content".to_string()))?
                     .to_owned(),
             ));
         } else if update.tag_name().name() == "delta-update" {
             let windowid =
                 update
                     .attribute("windowid")
-                    .ok_or(BodyUpdateError::CannotFindAttribute {
+                    .ok_or(BodyUpdateError::NoSuchAttribute {
                         node: "delta-update".to_string(),
                         attribute: "windowid".to_string(),
                     })?;
@@ -89,19 +89,19 @@ impl BodyUpdate {
                 match tag_name {
                     "control-update" => {
                         let control_id = children.attribute("id").ok_or(
-                            BodyUpdateError::CannotFindAttribute {
+                            BodyUpdateError::NoSuchAttribute {
                                 node: "control-update".to_string(),
                                 attribute: "id".to_string(),
                             },
                         )?;
                         let content = children
                             .first_child()
-                            .ok_or(BodyUpdateError::NoContent("control-update".to_string()))?;
+                            .ok_or(BodyUpdateError::NoSuchContent("control-update".to_string()))?;
                         update_map.insert(
                             control_id.to_owned(),
                             content
                                 .text()
-                                .ok_or(BodyUpdateError::NoContent("content".to_string()))?
+                                .ok_or(BodyUpdateError::NoSuchContent("content".to_string()))?
                                 .to_owned(),
                         );
                     }

--- a/src/webdynpro/application/client/mod.rs
+++ b/src/webdynpro/application/client/mod.rs
@@ -2,11 +2,10 @@ use self::body::{Body, BodyUpdate};
 use crate::{
     utils::{default_header, DEFAULT_USER_AGENT},
     webdynpro::{
-        error::ClientError,
+        error::{ClientError, WebDynproError},
         event::{event_queue::EventQueue, Event},
     },
 };
-use anyhow::Result;
 use reqwest::{cookie::Jar, header::*, RequestBuilder};
 use std::sync::Arc;
 use url::Url;
@@ -42,7 +41,7 @@ pub(super) fn wd_xhr_header() -> HeaderMap {
 }
 
 impl Client {
-    pub async fn new(base_url: &Url, app_name: &str) -> Result<Client> {
+    pub async fn new(base_url: &Url, app_name: &str) -> Result<Client, ClientError> {
         let jar: Arc<Jar> = Arc::new(Jar::default());
         let client = reqwest::Client::builder()
             .cookie_provider(jar)
@@ -57,7 +56,7 @@ impl Client {
         client: reqwest::Client,
         base_url: &Url,
         app_name: &str,
-    ) -> Result<Client> {
+    ) -> Result<Client, ClientError> {
         let raw_body = client
             .wd_navigate(base_url, app_name)
             .send()
@@ -79,12 +78,12 @@ impl Client {
         self.event_queue.add(event)
     }
 
-    pub(crate) async fn send_event(&mut self, base_url: &Url) -> Result<()> {
+    pub(crate) async fn send_event(&mut self, base_url: &Url) -> Result<(), WebDynproError> {
         let res = self.event_request(base_url).await?;
         self.mutate_body(res)
     }
 
-    async fn event_request(&mut self, base_url: &Url) -> Result<String> {
+    async fn event_request(&mut self, base_url: &Url) -> Result<String, ClientError> {
         let res = self
             .client
             .wd_xhr(base_url, &self.ssr_client, &mut self.event_queue)?
@@ -96,7 +95,7 @@ impl Client {
         Ok(res.text().await?)
     }
 
-    fn mutate_body(&mut self, response: String) -> Result<()> {
+    fn mutate_body(&mut self, response: String) -> Result<(), WebDynproError> {
         let body = &mut self.body;
         let update = BodyUpdate::new(&response)?;
         Ok(body.apply(update)?)
@@ -111,7 +110,7 @@ trait Requests {
         base_url: &Url,
         ssr_client: &SapSsrClient,
         event_queue: &mut EventQueue,
-    ) -> Result<RequestBuilder>;
+    ) -> Result<RequestBuilder, ClientError>;
 }
 
 impl Requests for reqwest::Client {
@@ -131,7 +130,7 @@ impl Requests for reqwest::Client {
         base_url: &Url,
         ssr_client: &SapSsrClient,
         event_queue: &mut EventQueue,
-    ) -> Result<RequestBuilder> {
+    ) -> Result<RequestBuilder, ClientError> {
         let mut url = "".to_owned();
         url.push_str(base_url.scheme());
         url.push_str("://");

--- a/src/webdynpro/application/client/mod.rs
+++ b/src/webdynpro/application/client/mod.rs
@@ -138,7 +138,7 @@ impl Requests for reqwest::Client {
         if let Some(host_str) = base_url.host_str() {
             url.push_str(host_str);
         } else {
-            return Err(ClientError::InvalidBaseUrl)?;
+            return Err(ClientError::InvalidBaseUrl(base_url.to_string()))?;
         }
         if let Some(port) = base_url.port() {
             url.push_str(":");

--- a/src/webdynpro/application/mod.rs
+++ b/src/webdynpro/application/mod.rs
@@ -1,10 +1,9 @@
 use self::client::{body::Body, Client};
-use anyhow::Result;
 use url::Url;
 
 use super::{
     element::{define_elements, layout::form::Form},
-    error::ClientError,
+    error::{ClientError, WebDynproError},
     event::Event,
 };
 
@@ -19,13 +18,14 @@ impl<'a> BasicApplication {
         SSR_FORM: Form<'a> = "sap.client.SsrClient.form"
     }
 
-    pub async fn new(base_url_str: &str, name: &str) -> Result<Self> {
-        let base_url = Url::parse(base_url_str)?;
+    pub async fn new(base_url_str: &str, name: &str) -> Result<Self, WebDynproError> {
+        let base_url = Url::parse(base_url_str)
+            .or(Err(ClientError::InvalidBaseUrl(base_url_str.to_string())))?;
         let client = Client::new(&base_url, name).await?;
         Ok(Self::with_client(base_url, name, client)?)
     }
 
-    pub fn with_client(base_url: Url, name: &str, client: Client) -> Result<Self> {
+    pub fn with_client(base_url: Url, name: &str, client: Client) -> Result<Self, WebDynproError> {
         Ok(BasicApplication {
             base_url,
             name: name.to_owned(),
@@ -44,7 +44,7 @@ impl<'a> BasicApplication {
         url
     }
 
-    pub async fn send_events(&mut self, events: Vec<Event>) -> Result<()> {
+    pub async fn send_events(&mut self, events: Vec<Event>) -> Result<(), WebDynproError> {
         let form_req = Self::SSR_FORM
             .from_body(&self.client.body)?
             .request(false, "", "", false, false)

--- a/src/webdynpro/application/mod.rs
+++ b/src/webdynpro/application/mod.rs
@@ -48,7 +48,9 @@ impl<'a> BasicApplication {
         let form_req = Self::SSR_FORM
             .from_body(&self.client.body)?
             .request(false, "", "", false, false)
-            .or(Err(ClientError::NoForm))?;
+            .or(Err(ClientError::NoSuchForm(
+                Self::SSR_FORM.id().to_string(),
+            )))?;
         for event in events.into_iter() {
             if !event.is_enqueable() && event.is_submitable() {
                 {

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
-use crate::webdynpro::{event::Event, element::{define_element_interactable, Interactable}};
-
+use crate::webdynpro::{
+    element::{define_element_interactable, Interactable},
+    event::Event, error::WebDynproError,
+};
 
 define_element_interactable! {
     Button<"B", "Button"> {},
@@ -52,7 +53,7 @@ impl<'a> Button<'a> {
         }
     }
 
-    pub fn press(&self) -> Result<Event> {
+    pub fn press(&self) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("Press".to_string(), parameters)

--- a/src/webdynpro/element/action/link.rs
+++ b/src/webdynpro/element/action/link.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use crate::webdynpro::{
     element::{define_element_interactable, Interactable},
+    error::WebDynproError,
     event::Event,
 };
 
@@ -35,7 +35,7 @@ impl<'a> Link<'a> {
         }
     }
 
-    pub fn activate(&self, ctrl: bool, shift: bool) -> Result<Event> {
+    pub fn activate(&self, ctrl: bool, shift: bool) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         parameters.insert("Ctrl".to_string(), ctrl.to_string());
@@ -43,7 +43,7 @@ impl<'a> Link<'a> {
         self.fire_event("Activate".to_string(), parameters)
     }
 
-    pub fn double_click(&self) -> Result<Event> {
+    pub fn double_click(&self) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("DoubleClick".to_string(), parameters)

--- a/src/webdynpro/element/complex/sap_table/cell/header_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/header_cell.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use getset::Getters;
 use std::{borrow::Cow, cell::OnceCell};
 
@@ -7,7 +6,7 @@ use serde::Deserialize;
 
 use crate::webdynpro::{
     element::{Element, ElementWrapper, SubElement, SubElementDef},
-    error::BodyError,
+    error::{BodyError, WebDynproError},
 };
 
 use super::{SapTableCell, SapTableCellWrapper};
@@ -81,7 +80,7 @@ impl<'a> SubElement<'a> for SapTableHeaderCell<'a> {
     fn from_elem<Parent: Element<'a>>(
         elem_def: SubElementDef<'a, Parent, Self>,
         element: scraper::ElementRef<'a>,
-    ) -> Result<Self> {
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 

--- a/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use getset::Getters;
 use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 use serde::Deserialize;
 
-use crate::webdynpro::element::{Element, ElementWrapper, SubElement, SubElementDef};
+use crate::webdynpro::{element::{Element, ElementWrapper, SubElement, SubElementDef}, error::WebDynproError};
 
 use super::{SapTableCell, SapTableCellWrapper};
 
@@ -79,7 +78,7 @@ impl<'a> SubElement<'a> for SapTableHierarchicalCell<'a> {
     fn from_elem<Parent: Element<'a>>(
         elem_def: SubElementDef<'a, Parent, Self>,
         element: scraper::ElementRef<'a>,
-    ) -> Result<Self> {
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 

--- a/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
@@ -1,11 +1,13 @@
-use anyhow::Result;
 use getset::Getters;
 use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 use serde::Deserialize;
 
-use crate::webdynpro::element::{Element, ElementWrapper, SubElement, SubElementDef};
+use crate::webdynpro::{
+    element::{Element, ElementWrapper, SubElement, SubElementDef},
+    error::WebDynproError,
+};
 
 use super::{SapTableCell, SapTableCellWrapper};
 
@@ -67,7 +69,7 @@ impl<'a> SubElement<'a> for SapTableMatrixCell<'a> {
     fn from_elem<Parent: Element<'a>>(
         elem_def: SubElementDef<'a, Parent, Self>,
         element: scraper::ElementRef<'a>,
-    ) -> Result<Self> {
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 

--- a/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
@@ -1,11 +1,13 @@
-use anyhow::Result;
 use getset::Getters;
 use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 use serde::Deserialize;
 
-use crate::webdynpro::element::{Element, ElementWrapper, SubElement, SubElementDef};
+use crate::webdynpro::{
+    element::{Element, ElementWrapper, SubElement, SubElementDef},
+    error::WebDynproError,
+};
 
 use super::{SapTableCell, SapTableCellWrapper};
 
@@ -75,7 +77,7 @@ impl<'a> SubElement<'a> for SapTableNormalCell<'a> {
     fn from_elem<Parent: Element<'a>>(
         elem_def: SubElementDef<'a, Parent, Self>,
         element: scraper::ElementRef<'a>,
-    ) -> Result<Self> {
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 

--- a/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
@@ -1,11 +1,13 @@
-use anyhow::Result;
 use getset::Getters;
 use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 use serde::Deserialize;
 
-use crate::webdynpro::element::{Element, ElementWrapper, SubElement, SubElementDef};
+use crate::webdynpro::{
+    element::{Element, ElementWrapper, SubElement, SubElementDef},
+    error::WebDynproError,
+};
 
 use super::{SapTableCell, SapTableCellWrapper};
 
@@ -75,7 +77,7 @@ impl<'a> SubElement<'a> for SapTableSelectionCell<'a> {
     fn from_elem<Parent: Element<'a>>(
         elem_def: SubElementDef<'a, Parent, Self>,
         element: scraper::ElementRef<'a>,
-    ) -> Result<Self> {
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use scraper::Selector;
 
 use crate::webdynpro::{
     element::{define_element_interactable, ElementDef, Interactable, SubElement, SubElementDef},
-    error::{BodyError, ElementError},
+    error::{BodyError, ElementError, WebDynproError},
     event::Event,
 };
 
@@ -67,7 +66,7 @@ impl<'a> SapTable<'a> {
         self.table.get_or_init(|| self.parse_table().ok()).as_ref()
     }
 
-    fn parse_table(&self) -> Result<SapTableBody<'a>> {
+    fn parse_table(&self) -> Result<SapTableBody<'a>, WebDynproError> {
         let def: ElementDef<'a, SapTable<'a>> = {
             if let Cow::Borrowed(id) = self.id {
                 ElementDef::new(id)
@@ -165,7 +164,7 @@ impl<'a> SapTable<'a> {
         cell_user_data: &str,
         access_type: AccessType,
         trigger_cell_id: &str,
-    ) -> Result<Event> {
+    ) -> Result<Event, WebDynproError> {
         let parameters: HashMap<String, String> = HashMap::from([
             ("Id".to_string(), self.id.clone().to_string()),
             ("RowIndex".to_string(), format!("{}", row_index)),
@@ -186,7 +185,7 @@ impl<'a> SapTable<'a> {
         row_user_data: &str,
         cell_user_data: &str,
         access_type: AccessType,
-    ) -> Result<Event> {
+    ) -> Result<Event, WebDynproError> {
         let parameters: HashMap<String, String> = HashMap::from([
             ("Id".to_string(), self.id.clone().to_string()),
             ("CellId".to_string(), cell_id.to_owned()),

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -80,9 +80,10 @@ impl<'a> SapTable<'a> {
         let tbody_selector = Selector::parse(
             format!(
                 r#"[id="{}-contentTBody"]"#,
-                elem_value
-                    .id()
-                    .ok_or(ElementError::NoSuchAttribute("id".to_string()))?
+                elem_value.id().ok_or(ElementError::NoSuchData {
+                    element: self.id.clone().into_owned(),
+                    field: "id".to_string()
+                })?
             )
             .as_str(),
         )
@@ -90,7 +91,10 @@ impl<'a> SapTable<'a> {
         let tbody = element
             .select(&tbody_selector)
             .next()
-            .ok_or(ElementError::NoSuchElement)?;
+            .ok_or(ElementError::NoSuchContent {
+                element: self.id.clone().into_owned(),
+                content: "Table content".to_string(),
+            })?;
         Ok(tbody
             .children()
             .filter_map(|node| scraper::ElementRef::wrap(node))

--- a/src/webdynpro/element/layout/form.rs
+++ b/src/webdynpro/element/layout/form.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
+use crate::webdynpro::error::WebDynproError;
 use crate::webdynpro::event::Event;
 
 use crate::webdynpro::element::{define_element_interactable, Interactable};
@@ -47,7 +47,7 @@ impl<'a> Form<'a> {
         hash: &str,
         dom_changed: bool,
         is_dirty: bool,
-    ) -> Result<Event> {
+    ) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         parameters.insert("Async".to_string(), is_async.to_string());

--- a/src/webdynpro/element/layout/popup_window.rs
+++ b/src/webdynpro/element/layout/popup_window.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
-
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
+use crate::webdynpro::error::WebDynproError;
 use crate::webdynpro::event::Event;
 
 use crate::webdynpro::element::{define_element_interactable, Interactable};
@@ -55,13 +54,13 @@ impl<'a> PopupWindow<'a> {
         }
     }
 
-    pub fn close(&self) -> Result<Event> {
+    pub fn close(&self) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("Close".to_string(), parameters)
     }
 
-    pub fn help(&self) -> Result<Event> {
+    pub fn help(&self) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("Help".to_string(), parameters)

--- a/src/webdynpro/element/layout/tab_strip/mod.rs
+++ b/src/webdynpro/element/layout/tab_strip/mod.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use scraper::Selector;
 
 use crate::webdynpro::{
     element::{define_element_interactable, Element, ElementDef, Interactable},
-    error::BodyError,
+    error::{BodyError, WebDynproError},
     event::Event,
 };
 
@@ -74,7 +73,7 @@ impl<'a> TabStrip<'a> {
         item_id: &str,
         item_index: u32,
         first_visible_item_index: u32,
-    ) -> Result<Event> {
+    ) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         parameters.insert("ItemId".to_string(), item_id.to_string());

--- a/src/webdynpro/element/selection/combo_box.rs
+++ b/src/webdynpro/element/selection/combo_box.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
-use crate::webdynpro::error::BodyError;
+use crate::webdynpro::error::{BodyError, WebDynproError};
 use crate::webdynpro::{application::client::body::Body, error::ElementError, event::Event};
 
 use crate::webdynpro::element::{
@@ -56,11 +55,14 @@ impl<'a> ComboBox<'a> {
         }
     }
 
-    pub fn item_list_box(&self, body: &'a Body) -> Result<ListBoxWrapper<'a>> {
+    pub fn item_list_box(&self, body: &'a Body) -> Result<ListBoxWrapper<'a>, WebDynproError> {
         let listbox_id = self
             .lsdata()
             .and_then(|lsdata| lsdata.item_list_box_id.as_ref())
-            .ok_or(ElementError::NoSuchData { element: self.id().to_string(), field: "item_list_box_id".to_string() })?;
+            .ok_or(ElementError::NoSuchData {
+                element: self.id().to_string(),
+                field: "item_list_box_id".to_string(),
+            })?;
         let selector = scraper::Selector::parse(format!(r#"[id="{}"]"#, listbox_id).as_str())
             .or(Err(ElementError::InvalidId(listbox_id.to_owned())))?;
         let elem = body
@@ -74,7 +76,7 @@ impl<'a> ComboBox<'a> {
         )
     }
 
-    pub fn select(&self, key: &str, by_enter: bool) -> Result<Event> {
+    pub fn select(&self, key: &str, by_enter: bool) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         parameters.insert("Key".to_string(), key.to_string());

--- a/src/webdynpro/element/selection/combo_box.rs
+++ b/src/webdynpro/element/selection/combo_box.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
+use crate::webdynpro::error::BodyError;
 use crate::webdynpro::{application::client::body::Body, error::ElementError, event::Event};
 
 use crate::webdynpro::element::{
@@ -59,17 +60,17 @@ impl<'a> ComboBox<'a> {
         let listbox_id = self
             .lsdata()
             .and_then(|lsdata| lsdata.item_list_box_id.as_ref())
-            .ok_or(ElementError::InvalidLSData)?;
+            .ok_or(ElementError::NoSuchData { element: self.id().to_string(), field: "item_list_box_id".to_string() })?;
         let selector = scraper::Selector::parse(format!(r#"[id="{}"]"#, listbox_id).as_str())
             .or(Err(ElementError::InvalidId(listbox_id.to_owned())))?;
         let elem = body
             .document()
             .select(&selector)
             .next()
-            .ok_or(ElementError::NoSuchElement)?;
+            .ok_or(BodyError::NoSuchElement(listbox_id.to_owned()))?;
         Ok(
             ListBoxWrapper::from_elements(ElementWrapper::dyn_elem(elem)?)
-                .ok_or(ElementError::NoSuchElement)?,
+                .ok_or(BodyError::NoSuchElement(listbox_id.to_owned()))?,
         )
     }
 

--- a/src/webdynpro/element/selection/list_box/mod.rs
+++ b/src/webdynpro/element/selection/list_box/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, ops::DerefMut};
 
 use serde::Deserialize;
@@ -40,7 +39,7 @@ macro_rules! def_listbox_subset {
                     .as_ref()
             }
 
-            fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self> {
+            fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
                 Ok(Self::new(elem_def.id.to_owned(), element))
             }
 

--- a/src/webdynpro/element/system/client_inspector.rs
+++ b/src/webdynpro/element/system/client_inspector.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use serde::{Deserialize, Serialize};
 
+use crate::webdynpro::error::WebDynproError;
 use crate::webdynpro::event::Event;
 
 use crate::webdynpro::element::{
@@ -128,7 +128,7 @@ impl<'a> Element<'a> for ClientInspector<'a> {
             .as_ref()
     }
 
-    fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self> {
+    fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 
@@ -167,7 +167,7 @@ impl<'a> ClientInspector<'a> {
         }
     }
 
-    pub fn notify(&self, data: &str) -> Result<Event> {
+    pub fn notify(&self, data: &str) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
 
         parameters.insert("Id".to_string(), self.id.clone().to_string());

--- a/src/webdynpro/element/system/custom.rs
+++ b/src/webdynpro/element/system/custom.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
 use std::{borrow::Cow, collections::HashMap};
 
 use crate::webdynpro::{
     element::ElementWrapper,
+    error::WebDynproError,
     event::{
         ucf_parameters::{UcfAction, UcfParametersBuilder, UcfResponseData},
         Event, EventBuilder,
@@ -74,7 +74,10 @@ impl<'a> Element<'a> for Custom {
         None
     }
 
-    fn from_elem(elem_def: ElementDef<'_, Self>, _element: scraper::ElementRef) -> Result<Self> {
+    fn from_elem(
+        elem_def: ElementDef<'_, Self>,
+        _element: scraper::ElementRef,
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned()))
     }
 

--- a/src/webdynpro/element/system/loading_placeholder.rs
+++ b/src/webdynpro/element/system/loading_placeholder.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
+use crate::webdynpro::error::WebDynproError;
 use crate::webdynpro::event::Event;
 
 use crate::webdynpro::element::{define_element_interactable, Interactable};
@@ -23,7 +23,7 @@ impl<'a> LoadingPlaceholder<'a> {
         }
     }
 
-    pub fn load(&self) -> Result<Event> {
+    pub fn load(&self) -> Result<Event, WebDynproError> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("Load".to_string(), parameters)

--- a/src/webdynpro/element/unknown.rs
+++ b/src/webdynpro/element/unknown.rs
@@ -1,7 +1,8 @@
-use anyhow::Result;
 use std::{borrow::Cow, cell::OnceCell};
 
 use serde_json::Value;
+
+use crate::webdynpro::error::WebDynproError;
 
 use super::{Element, ElementDef, EventParameterMap, Interactable};
 
@@ -31,7 +32,10 @@ impl<'a> Element<'a> for Unknown<'a> {
             .as_ref()
     }
 
-    fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self> {
+    fn from_elem(
+        elem_def: ElementDef<'a, Self>,
+        element: scraper::ElementRef<'a>,
+    ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))
     }
 

--- a/src/webdynpro/error/mod.rs
+++ b/src/webdynpro/error/mod.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum RusaintError {
+pub enum WebDynproError {
     #[error("Error in client request/response: {0}")]
     ClientError(#[from] ClientError),
     #[error("Error in parsing document body: {0}")]
@@ -64,6 +64,8 @@ pub enum BodyError {
     NoSuchElement(String),
     #[error("Cannot find attribute: {0}")]
     NoSuchAttribute(String),
+    #[error("Cannot parse event str/struct: {0}")]
+    CannotParseEvents(#[from] EventStrUnescapeError)
 }
 
 #[derive(Error, Debug)]

--- a/src/webdynpro/event/mod.rs
+++ b/src/webdynpro/event/mod.rs
@@ -3,6 +3,8 @@ use derive_builder::Builder;
 
 use std::{borrow::Cow, collections::HashMap, num::ParseIntError};
 
+use super::error::EventStrUnescapeError;
+
 const EVENT_SPECTATOR: &str = "~E001";
 const EVENT_DATA_START: &str = "~E002";
 const EVENT_DATA_END: &str = "~E003";
@@ -41,7 +43,7 @@ fn decode_hex(s: &str) -> Result<Vec<u16>, ParseIntError> {
         .collect()
 }
 
-pub fn unescape_str<'a>(text: &'a str) -> anyhow::Result<Cow<'a, str>> {
+pub fn unescape_str<'a>(text: &'a str) -> Result<Cow<'a, str>, EventStrUnescapeError> {
     let bytes = text.as_bytes();
 
     let mut owned = None;

--- a/tests/webdynpro/element/button.rs
+++ b/tests/webdynpro/element/button.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
 use rusaint::{
     define_elements,
-    webdynpro::element::{
+    webdynpro::{element::{
         action::{button::Button, link::Link},
         text::text_view::TextView,
-    },
+    }, error::WebDynproError},
 };
 
 use crate::get_session;
@@ -19,7 +18,7 @@ impl<'a> EventTestSuite {
         TEST_BUTTON_TEXTVIEW: TextView<'a> = "WDR_TEST_EVENTS.ID_0001:BUTTON.TEXTVIEW",
     }
 
-    async fn test_button(&mut self) -> Result<()> {
+    async fn test_button(&mut self) -> Result<(), WebDynproError> {
         let load_btn_pane = {
             let body = self.body();
             let link = Self::LINK_TO_BUTTON.from_body(body)?;

--- a/tests/webdynpro/element/mod.rs
+++ b/tests/webdynpro/element/mod.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
 use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
 
-use rusaint::{application::USaintApplication, session::USaintSession};
+use rusaint::{application::USaintApplication, session::USaintSession, webdynpro::error::WebDynproError};
 
 pub(crate) struct EventTestSuite(USaintApplication);
 
@@ -24,7 +23,7 @@ impl<'a> DerefMut for EventTestSuite {
 impl<'a> EventTestSuite {
     const APP_NAME: &str = "WDR_TEST_EVENTS";
 
-    pub async fn new(session: Arc<USaintSession>) -> Result<EventTestSuite> {
+    pub async fn new(session: Arc<USaintSession>) -> Result<EventTestSuite, WebDynproError> {
         Ok(EventTestSuite(
             USaintApplication::with_session(Self::APP_NAME, session).await?,
         ))


### PR DESCRIPTION
# What’s in this pull request
- 에러 원인을 추적할 수 있도록 각 에러에 기본적인 정보를 포함하도록 하였습니다.
- 각 분류별 에러를 추가, 이름 변경하여 적절한 오류가 표시되도록 수정했습니다.
- WebDynproError, RusaintError 를 추가하여 전체 오류 타입이 한번에 표시되도록 했습니다.
- 오류를 직접 변환, 핸들링하므로 `anyhow` 크레이트를 일반 빌드에서 제거했습니다.