### PR TITLE
[feat] u-saint 애플리케이션 구현을 feature 로 분리

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,19 @@ license = "MIT"
 repository = "https://github.com/EATSTEAK/rusaint"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["application", "model"]
+application = []
+model = ["application"]
 
 [dependencies]
 derive_builder = "0.12.0"
-reqwest = { version = "0.11.18", features = ["cookies", "gzip", "brotli", "deflate"] }
+reqwest = { version = "0.11.18", features = [
+    "cookies",
+    "gzip",
+    "brotli",
+    "deflate",
+] }
 thiserror = "1.0.44"
 tokio = { version = "1.29.1", features = ["macros", "test-util"] }
 html-escape = "0.2.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "application")]
 pub mod application;
+#[cfg(feature = "application")]
 pub mod error;
+#[cfg(feature = "model")]
 pub mod model;
+#[cfg(feature = "application")]
 pub mod session;
 pub mod utils;
 pub mod webdynpro;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,16 +1,8 @@
-use std::sync::Arc;
-
-use reqwest::{
-    cookie::Jar,
-    header::{HeaderMap, ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, CONNECTION},
-    Client,
+use reqwest::header::{
+    HeaderMap, ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, CONNECTION,
 };
 
-use crate::error::SsuSsoError;
-
 pub(crate) const DEFAULT_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
-const SMARTID_LOGIN_URL: &str = "https://smartid.ssu.ac.kr/Symtra_sso/smln.asp";
-const SMARTID_LOGIN_FORM_REQUEST_URL: &str = "https://smartid.ssu.ac.kr/Symtra_sso/smln_pcs.asp";
 
 pub(crate) fn default_header() -> HeaderMap {
     let mut headers = HeaderMap::new();
@@ -25,70 +17,4 @@ pub(crate) fn default_header() -> HeaderMap {
     headers.insert(CACHE_CONTROL, "max-age=0".parse().unwrap());
     headers.insert(CONNECTION, "keep-alive".parse().unwrap());
     headers
-}
-
-pub async fn obtain_ssu_sso_token(id: &str, password: &str) -> Result<String, SsuSsoError> {
-    let jar: Arc<Jar> = Arc::new(Jar::default());
-    let client = Client::builder()
-        .cookie_provider(jar)
-        .cookie_store(true)
-        .user_agent(DEFAULT_USER_AGENT)
-        .build()
-        .unwrap();
-    let body = client
-        .get(SMARTID_LOGIN_URL)
-        .headers(default_header())
-        .send()
-        .await?
-        .text()
-        .await?;
-    let document = scraper::Html::parse_document(&body);
-    let in_tp_bit_selector = scraper::Selector::parse(r#"input[name="in_tp_bit"]"#).unwrap();
-    let rqst_caus_cd_selector = scraper::Selector::parse(r#"input[name="rqst_caus_cd"]"#).unwrap();
-    let in_tp_bit = document
-        .select(&in_tp_bit_selector)
-        .next()
-        .ok_or(SsuSsoError::CantLoadForm)?
-        .value()
-        .attr("value")
-        .ok_or(SsuSsoError::CantLoadForm)?;
-    let rqst_caus_cd = document
-        .select(&rqst_caus_cd_selector)
-        .next()
-        .ok_or(SsuSsoError::CantLoadForm)?
-        .value()
-        .attr("value")
-        .ok_or(SsuSsoError::CantLoadForm)?;
-    let params = [
-        ("in_tp_bit", in_tp_bit),
-        ("rqst_caus_cd", rqst_caus_cd),
-        ("userid", id),
-        ("pwd", password),
-    ];
-    let res = client
-        .post(SMARTID_LOGIN_FORM_REQUEST_URL)
-        .headers(default_header())
-        .form(&params)
-        .send()
-        .await?;
-    let cookie_token = res
-        .cookies()
-        .find(|cookie| cookie.name() == "sToken" && !cookie.value().is_empty())
-        .ok_or(SsuSsoError::CantFindToken)?;
-    Ok(cookie_token.value().to_string())
-}
-
-#[cfg(test)]
-mod test {
-    use crate::utils::obtain_ssu_sso_token;
-    use dotenv::dotenv;
-
-    #[tokio::test]
-    async fn test_obtain_sso_token() {
-        dotenv().ok();
-        let id = std::env::var("SSO_ID").unwrap();
-        let password = std::env::var("SSO_PASSWORD").unwrap();
-        let token = obtain_ssu_sso_token(&id, &password).await.unwrap();
-        assert_ne!("", token);
-    }
 }


### PR DESCRIPTION
# What's in this pull request
- WebDynpro 엔진 구현과 관련 없는 u-saint 관련 구현을 `model`과 `application` feature로 분리하였습니다.
- `application` feature는 `model` feature를 요구하며, 두 feature는 기본적으로 포함되므로 임의로 기본 feature를 제거하지 않는 이상 외부 변경사항은 없습니다.