### PR TITLE
[refactor] 오류와 세션 코드를 라이브러리 루트로 Re-export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,21 @@
 #[cfg(feature = "application")]
 pub mod application;
 #[cfg(feature = "application")]
-pub mod error;
+mod error;
+#[cfg(feature = "application")]
+pub use error::RusaintError;
+#[cfg(feature = "application")]
+pub use error::SsuSsoError;
+#[cfg(feature = "application")]
+mod session;
+
+#[cfg(feature = "application")]
+pub use session::obtain_ssu_sso_token;
+#[cfg(feature = "application")]
+pub use session::USaintSession;
+
 #[cfg(feature = "model")]
 pub mod model;
-#[cfg(feature = "application")]
-pub mod session;
-pub mod utils;
+
+mod utils;
 pub mod webdynpro;

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use std::sync::{Arc, OnceLock};
 
 use dotenv::dotenv;
-use rusaint::{application::CourseGrades, model::SemesterType, session::USaintSession};
+use rusaint::{application::CourseGrades, model::SemesterType, USaintSession};
 use serial_test::serial;
 
 static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,7 @@ use anyhow::{Error, Result};
 use dotenv::dotenv;
 use std::sync::{Arc, OnceLock};
 
-use rusaint::session::USaintSession;
+use rusaint::USaintSession;
 
 static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();
 

--- a/tests/webdynpro/element/mod.rs
+++ b/tests/webdynpro/element/mod.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use rusaint::{application::USaintApplication, session::USaintSession, webdynpro::error::WebDynproError};
+use rusaint::{application::USaintApplication, webdynpro::error::WebDynproError, USaintSession};
 
 pub(crate) struct EventTestSuite(USaintApplication);
 


### PR DESCRIPTION
# What's in this pull request
- `error::RusaintError`, `error::SsuSsoError`, `session::USaintSession`, `session::obtain_ssu_sso_token` 을 라이브러리 루트로 이동