### PR TITLE
[refactor] `SapTable` 내용 파싱 개선

### DIFF
--- a/src/application/course_schedule.rs
+++ b/src/application/course_schedule.rs
@@ -4,10 +4,7 @@ use crate::{
     define_elements,
     model::SemesterType,
     webdynpro::{
-        element::{
-            action::Button, complex::SapTable, layout::TabStrip,
-            selection::ComboBox,
-        },
+        element::{action::Button, complex::SapTable, layout::TabStrip, selection::ComboBox},
         error::WebDynproError,
     },
 };
@@ -168,9 +165,9 @@ mod test {
         app.load_edu().await.unwrap();
         let table = app.read_edu_raw().unwrap();
         if let Some(table) = table.table() {
-            for row in table {
+            for row in table.with_header() {
                 print!("row: ");
-                for col in row {
+                for col in row.iter() {
                     match col {
                         SapTableCellWrapper::Header(cell) => {
                             let content = cell.content();

--- a/src/webdynpro/element/complex/sap_table/body.rs
+++ b/src/webdynpro/element/complex/sap_table/body.rs
@@ -1,0 +1,118 @@
+use scraper::ElementRef;
+
+use crate::webdynpro::{element::ElementDef, error::ElementError};
+
+use super::{
+    cell::SapTableCellWrapper,
+    property::{SapTableRowType, SapTableSelectionState},
+    SapTable,
+};
+
+pub struct SapTableBody<'a> {
+    table_def: ElementDef<'a, SapTable<'a>>,
+    elem_ref: ElementRef<'a>,
+    header: SapTableRow<'a>,
+    rows: Vec<SapTableRow<'a>>,
+}
+
+impl<'a> SapTableBody<'a> {
+    pub(super) fn new(
+        table_def: ElementDef<'a, SapTable<'a>>,
+        elem_ref: ElementRef<'a>,
+    ) -> Result<SapTableBody<'a>, ElementError> {
+        let rows_iter = elem_ref
+            .children()
+            .filter_map(|node| scraper::ElementRef::wrap(node))
+            .filter_map(|row_ref| SapTableRow::new(table_def, row_ref).ok());
+        let mut header_iter = rows_iter
+            .clone()
+            .filter(|row| matches!(row.row_type, SapTableRowType::Header));
+        let Some(header) = header_iter.next() else {
+            return Err(ElementError::NoSuchContent { element: table_def.id().to_owned(), content: "Header of table".to_owned() });
+        };
+        if header_iter.next().is_some() {
+            return Err(ElementError::InvalidContent {
+                element: table_def.id().to_owned(),
+                content: "Multiple header in table".to_owned(),
+            });
+        }
+        let rows = rows_iter.skip(1).collect::<Vec<SapTableRow<'a>>>();
+        Ok(SapTableBody {
+            table_def,
+            elem_ref,
+            header,
+            rows,
+        })
+    }
+}
+
+pub struct SapTableRow<'a> {
+    table_def: ElementDef<'a, SapTable<'a>>,
+    elem_ref: ElementRef<'a>,
+    cells: Vec<SapTableCellWrapper<'a>>,
+    row_index: Option<u32>,
+    user_data: Option<String>,
+    drag_data: Option<String>,
+    drop_target_info: Option<String>,
+    parent_drop_target_info: Option<String>,
+    selection_state: SapTableSelectionState,
+    row_type: SapTableRowType,
+}
+
+impl<'a> SapTableRow<'a> {
+    pub(super) fn new(
+        table_def: ElementDef<'a, SapTable<'a>>,
+        row_ref: ElementRef<'a>,
+    ) -> Result<SapTableRow<'a>, ElementError> {
+        let row = row_ref.value();
+        let subct_selector = scraper::Selector::parse("[subct]").unwrap();
+        let subcts = row_ref.select(&subct_selector);
+        let cells = subcts
+            .filter_map(|subct_ref| SapTableCellWrapper::dyn_cell(table_def, subct_ref))
+            .collect::<Vec<SapTableCellWrapper<'a>>>();
+        Ok(SapTableRow {
+            table_def,
+            elem_ref: row_ref,
+            cells,
+            row_index: row.attr("rr").and_then(|s| s.parse::<u32>().ok()),
+            user_data: row.attr("uDat").and_then(|s| Some(s.to_owned())),
+            drag_data: row.attr("ddData").and_then(|s| Some(s.to_owned())),
+            drop_target_info: row.attr("ddDti").and_then(|s| Some(s.to_owned())),
+            parent_drop_target_info: row.attr("ddPDti").and_then(|s| Some(s.to_owned())),
+            selection_state: row
+                .attr("sst")
+                .and_then(|s| Some(s.into()))
+                .unwrap_or(SapTableSelectionState::default()),
+            row_type: row
+                .attr("rt")
+                .and_then(|s| Some(s.into()))
+                .unwrap_or(SapTableRowType::default()),
+        })
+    }
+}
+
+impl From<&str> for SapTableSelectionState {
+    fn from(s: &str) -> Self {
+        match s {
+            "4" => Self::NotSelectable,
+            "0" => Self::NotSelected,
+            "2" => Self::Selected,
+            "1" => Self::PrimarySelected,
+            _ => Self::None,
+        }
+    }
+}
+
+impl From<&str> for SapTableRowType {
+    fn from(s: &str) -> Self {
+        match s {
+            "1" => Self::Standard,
+            "2" => Self::Header,
+            "3" => Self::Filter,
+            "4" => Self::TopFixed,
+            "5" => Self::BottomFixed,
+            "6" => Self::Pivot,
+            _ => Self::Unspecified,
+        }
+    }
+}

--- a/src/webdynpro/element/complex/sap_table/body.rs
+++ b/src/webdynpro/element/complex/sap_table/body.rs
@@ -1,15 +1,20 @@
+use std::{iter, ops::Deref};
+
 use scraper::ElementRef;
 
 use crate::webdynpro::{element::ElementDef, error::ElementError};
 
 use super::{
-    cell::SapTableCellWrapper,
-    property::{SapTableRowType, SapTableSelectionState},
+    property::SapTableRowType,
+    row::SapTableRow,
     SapTable,
 };
 
+#[derive(custom_debug_derive::Debug)]
+#[allow(unused)]
 pub struct SapTableBody<'a> {
     table_def: ElementDef<'a, SapTable<'a>>,
+    #[debug(skip)]
     elem_ref: ElementRef<'a>,
     header: SapTableRow<'a>,
     rows: Vec<SapTableRow<'a>>,
@@ -23,10 +28,10 @@ impl<'a> SapTableBody<'a> {
         let rows_iter = elem_ref
             .children()
             .filter_map(|node| scraper::ElementRef::wrap(node))
-            .filter_map(|row_ref| SapTableRow::new(table_def, row_ref).ok());
+            .filter_map(|row_ref| SapTableRow::new(table_def.clone(), row_ref).ok());
         let mut header_iter = rows_iter
             .clone()
-            .filter(|row| matches!(row.row_type, SapTableRowType::Header));
+            .filter(|row| matches!(row.row_type(), SapTableRowType::Header));
         let Some(header) = header_iter.next() else {
             return Err(ElementError::NoSuchContent { element: table_def.id().to_owned(), content: "Header of table".to_owned() });
         };
@@ -44,75 +49,30 @@ impl<'a> SapTableBody<'a> {
             rows,
         })
     }
-}
 
-pub struct SapTableRow<'a> {
-    table_def: ElementDef<'a, SapTable<'a>>,
-    elem_ref: ElementRef<'a>,
-    cells: Vec<SapTableCellWrapper<'a>>,
-    row_index: Option<u32>,
-    user_data: Option<String>,
-    drag_data: Option<String>,
-    drop_target_info: Option<String>,
-    parent_drop_target_info: Option<String>,
-    selection_state: SapTableSelectionState,
-    row_type: SapTableRowType,
-}
+    pub fn zip_header(&'a self) -> impl Iterator<Item = (&SapTableRow, &SapTableRow)> {
+        let header_iter = iter::repeat(self.header());
+        header_iter
+            .zip(self.rows.iter())
+    }
 
-impl<'a> SapTableRow<'a> {
-    pub(super) fn new(
-        table_def: ElementDef<'a, SapTable<'a>>,
-        row_ref: ElementRef<'a>,
-    ) -> Result<SapTableRow<'a>, ElementError> {
-        let row = row_ref.value();
-        let subct_selector = scraper::Selector::parse("[subct]").unwrap();
-        let subcts = row_ref.select(&subct_selector);
-        let cells = subcts
-            .filter_map(|subct_ref| SapTableCellWrapper::dyn_cell(table_def, subct_ref))
-            .collect::<Vec<SapTableCellWrapper<'a>>>();
-        Ok(SapTableRow {
-            table_def,
-            elem_ref: row_ref,
-            cells,
-            row_index: row.attr("rr").and_then(|s| s.parse::<u32>().ok()),
-            user_data: row.attr("uDat").and_then(|s| Some(s.to_owned())),
-            drag_data: row.attr("ddData").and_then(|s| Some(s.to_owned())),
-            drop_target_info: row.attr("ddDti").and_then(|s| Some(s.to_owned())),
-            parent_drop_target_info: row.attr("ddPDti").and_then(|s| Some(s.to_owned())),
-            selection_state: row
-                .attr("sst")
-                .and_then(|s| Some(s.into()))
-                .unwrap_or(SapTableSelectionState::default()),
-            row_type: row
-                .attr("rt")
-                .and_then(|s| Some(s.into()))
-                .unwrap_or(SapTableRowType::default()),
-        })
+    pub fn with_header(&'a self) -> impl Iterator<Item = &SapTableRow> {
+        [self.header()].into_iter().chain(self.rows.iter())
+    }
+
+    pub fn table_def(&self) -> ElementDef<'a, SapTable<'a>> {
+        self.table_def.clone()
+    }
+
+    pub fn header(&self) -> &SapTableRow<'a> {
+        &self.header
     }
 }
 
-impl From<&str> for SapTableSelectionState {
-    fn from(s: &str) -> Self {
-        match s {
-            "4" => Self::NotSelectable,
-            "0" => Self::NotSelected,
-            "2" => Self::Selected,
-            "1" => Self::PrimarySelected,
-            _ => Self::None,
-        }
-    }
-}
+impl<'a> Deref for SapTableBody<'a> {
+    type Target = Vec<SapTableRow<'a>>;
 
-impl From<&str> for SapTableRowType {
-    fn from(s: &str) -> Self {
-        match s {
-            "1" => Self::Standard,
-            "2" => Self::Header,
-            "3" => Self::Filter,
-            "4" => Self::TopFixed,
-            "5" => Self::BottomFixed,
-            "6" => Self::Pivot,
-            _ => Self::Unspecified,
-        }
+    fn deref(&self) -> &Self::Target {
+        &self.rows
     }
 }

--- a/src/webdynpro/element/complex/sap_table/cell/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/mod.rs
@@ -18,7 +18,7 @@ impl<'a> SapTableCellWrapper<'a> {
         match subct_value.attr("subct") {
             Some(SapTableNormalCell::SUBCONTROL_ID) => Some(
                 SubElementDef::<_, SapTableNormalCell>::new_dynamic(
-                    table_def.clone(),
+                    table_def,
                     subct_value.id()?.to_owned(),
                 )
                 .from_elem(elem_ref)
@@ -27,7 +27,7 @@ impl<'a> SapTableCellWrapper<'a> {
             ),
             Some(SapTableHeaderCell::SUBCONTROL_ID) => Some(
                 SubElementDef::<_, SapTableHeaderCell>::new_dynamic(
-                    table_def.clone(),
+                    table_def,
                     subct_value.id()?.to_owned(),
                 )
                 .from_elem(elem_ref)
@@ -36,7 +36,7 @@ impl<'a> SapTableCellWrapper<'a> {
             ),
             Some(SapTableHierarchicalCell::SUBCONTROL_ID) => Some(
                 SubElementDef::<_, SapTableHierarchicalCell>::new_dynamic(
-                    table_def.clone(),
+                    table_def,
                     subct_value.id()?.to_owned(),
                 )
                 .from_elem(elem_ref)
@@ -45,7 +45,7 @@ impl<'a> SapTableCellWrapper<'a> {
             ),
             Some(SapTableMatrixCell::SUBCONTROL_ID) => Some(
                 SubElementDef::<_, SapTableMatrixCell>::new_dynamic(
-                    table_def.clone(),
+                    table_def,
                     subct_value.id()?.to_owned(),
                 )
                 .from_elem(elem_ref)
@@ -54,7 +54,7 @@ impl<'a> SapTableCellWrapper<'a> {
             ),
             Some(SapTableSelectionCell::SUBCONTROL_ID) => Some(
                 SubElementDef::<_, SapTableSelectionCell>::new_dynamic(
-                    table_def.clone(),
+                    table_def,
                     subct_value.id()?.to_owned(),
                 )
                 .from_elem(elem_ref)

--- a/src/webdynpro/element/complex/sap_table/cell/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/mod.rs
@@ -1,4 +1,4 @@
-use crate::webdynpro::element::ElementWrapper;
+use crate::webdynpro::element::{ElementDef, ElementWrapper, SubElement, SubElementDef};
 
 #[derive(Debug)]
 pub enum SapTableCellWrapper<'a> {
@@ -10,6 +10,61 @@ pub enum SapTableCellWrapper<'a> {
 }
 
 impl<'a> SapTableCellWrapper<'a> {
+    pub fn dyn_cell(
+        table_def: ElementDef<'a, SapTable<'a>>,
+        elem_ref: scraper::ElementRef<'a>,
+    ) -> Option<SapTableCellWrapper<'a>> {
+        let subct_value = elem_ref.value();
+        match subct_value.attr("subct") {
+            Some(SapTableNormalCell::SUBCONTROL_ID) => Some(
+                SubElementDef::<_, SapTableNormalCell>::new_dynamic(
+                    table_def.clone(),
+                    subct_value.id()?.to_owned(),
+                )
+                .from_elem(elem_ref)
+                .ok()?
+                .wrap(),
+            ),
+            Some(SapTableHeaderCell::SUBCONTROL_ID) => Some(
+                SubElementDef::<_, SapTableHeaderCell>::new_dynamic(
+                    table_def.clone(),
+                    subct_value.id()?.to_owned(),
+                )
+                .from_elem(elem_ref)
+                .ok()?
+                .wrap(),
+            ),
+            Some(SapTableHierarchicalCell::SUBCONTROL_ID) => Some(
+                SubElementDef::<_, SapTableHierarchicalCell>::new_dynamic(
+                    table_def.clone(),
+                    subct_value.id()?.to_owned(),
+                )
+                .from_elem(elem_ref)
+                .ok()?
+                .wrap(),
+            ),
+            Some(SapTableMatrixCell::SUBCONTROL_ID) => Some(
+                SubElementDef::<_, SapTableMatrixCell>::new_dynamic(
+                    table_def.clone(),
+                    subct_value.id()?.to_owned(),
+                )
+                .from_elem(elem_ref)
+                .ok()?
+                .wrap(),
+            ),
+            Some(SapTableSelectionCell::SUBCONTROL_ID) => Some(
+                SubElementDef::<_, SapTableSelectionCell>::new_dynamic(
+                    table_def.clone(),
+                    subct_value.id()?.to_owned(),
+                )
+                .from_elem(elem_ref)
+                .ok()?
+                .wrap(),
+            ),
+            _ => None,
+        }
+    }
+
     pub fn content(&self) -> Option<&ElementWrapper<'a>> {
         match self {
             SapTableCellWrapper::Normal(elem) => elem.content(),
@@ -37,3 +92,5 @@ pub use self::hierarchical_cell::{SapTableHierarchicalCell, SapTableHierarchical
 pub use self::matrix_cell::{SapTableMatrixCell, SapTableMatrixCellLSData};
 pub use self::normal_cell::{SapTableNormalCell, SapTableNormalCellLSData};
 pub use self::selection_cell::{SapTableSelectionCell, SapTableSelectionCellLSData};
+
+use super::SapTable;

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -48,11 +48,10 @@ impl<'a> SapTable<'a> {
             }
         };
         let element = self.element_ref;
-        let elem_value = element.value();
         let tbody_selector = Selector::parse(
             format!(
                 r#"[id="{}-contentTBody"]"#,
-                elem_value.id().ok_or(ElementError::NoSuchData {
+                element.value().id().ok_or(ElementError::NoSuchData {
                     element: self.id.clone().into_owned(),
                     field: "id".to_string()
                 })?

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -8,9 +8,7 @@ use crate::webdynpro::{
     event::Event,
 };
 
-use self::{
-    property::AccessType, body::SapTableBody,
-};
+use self::{body::SapTableBody, property::AccessType};
 
 define_element_interactable! {
     #[doc = "테이블"]
@@ -62,13 +60,12 @@ impl<'a> SapTable<'a> {
             .as_str(),
         )
         .or(Err(BodyError::InvalidSelector))?;
-        let tbody = element
-            .select(&tbody_selector)
-            .next()
-            .ok_or(ElementError::NoSuchContent {
-                element: self.id.clone().into_owned(),
-                content: "Table body".to_string(),
-            })?;
+        let Some(tbody) = element.select(&tbody_selector).next() else {
+                return Err(ElementError::NoSuchContent {
+                    element: self.id.clone().into_owned(),
+                    content: "Table body".to_string(),
+                })?;
+            };
         Ok(SapTableBody::new(def, tbody)?)
     }
 

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -116,3 +116,4 @@ impl<'a> SapTable<'a> {
 pub mod body;
 pub mod cell;
 pub mod property;
+pub mod row;

--- a/src/webdynpro/element/complex/sap_table/property.rs
+++ b/src/webdynpro/element/complex/sap_table/property.rs
@@ -313,7 +313,7 @@ pub enum SapTableHierarchicalCellStatus {
     Icon,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SapTableSelectionState {
     NotSelectable,
@@ -321,7 +321,7 @@ pub enum SapTableSelectionState {
     Selected,
     PrimarySelected,
     #[default]
-    None
+    None,
 }
 
 #[derive(Deserialize, Debug)]
@@ -331,7 +331,7 @@ pub enum SapTableRowSelectionMassState {
     Indeterminate,
     All,
 }
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SapTableRowType {
     #[default]
@@ -341,7 +341,7 @@ pub enum SapTableRowType {
     Filter,
     TopFixed,
     BottomFixed,
-    Pivot
+    Pivot,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/webdynpro/element/complex/sap_table/property.rs
+++ b/src/webdynpro/element/complex/sap_table/property.rs
@@ -313,12 +313,35 @@ pub enum SapTableHierarchicalCellStatus {
     Icon,
 }
 
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SapTableSelectionState {
+    NotSelectable,
+    NotSelected,
+    Selected,
+    PrimarySelected,
+    #[default]
+    None
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SapTableRowSelectionMassState {
     None,
     Indeterminate,
     All,
+}
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SapTableRowType {
+    #[default]
+    Unspecified,
+    Standard,
+    Header,
+    Filter,
+    TopFixed,
+    BottomFixed,
+    Pivot
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/webdynpro/element/complex/sap_table/row.rs
+++ b/src/webdynpro/element/complex/sap_table/row.rs
@@ -1,0 +1,125 @@
+use std::ops::Deref;
+
+use scraper::ElementRef;
+
+use crate::webdynpro::{element::ElementDef, error::ElementError};
+
+use super::{
+    cell::SapTableCellWrapper,
+    property::{SapTableRowType, SapTableSelectionState},
+    SapTable,
+};
+
+#[derive(custom_debug_derive::Debug)]
+#[allow(unused)]
+pub struct SapTableRow<'a> {
+    table_def: ElementDef<'a, SapTable<'a>>,
+    #[debug(skip)]
+    elem_ref: ElementRef<'a>,
+    cells: Vec<SapTableCellWrapper<'a>>,
+    row_index: Option<u32>,
+    user_data: Option<String>,
+    drag_data: Option<String>,
+    drop_target_info: Option<String>,
+    parent_drop_target_info: Option<String>,
+    selection_state: SapTableSelectionState,
+    row_type: SapTableRowType,
+}
+
+impl<'a> SapTableRow<'a> {
+    pub(super) fn new(
+        table_def: ElementDef<'a, SapTable<'a>>,
+        row_ref: ElementRef<'a>,
+    ) -> Result<SapTableRow<'a>, ElementError> {
+        let row = row_ref.value();
+        let subct_selector = scraper::Selector::parse("[subct]").unwrap();
+        let subcts = row_ref.select(&subct_selector);
+        let cells = subcts
+            .filter_map(|subct_ref| SapTableCellWrapper::dyn_cell(table_def.clone(), subct_ref))
+            .collect::<Vec<SapTableCellWrapper<'a>>>();
+        Ok(SapTableRow {
+            table_def,
+            elem_ref: row_ref,
+            cells,
+            row_index: row.attr("rr").and_then(|s| s.parse::<u32>().ok()),
+            user_data: row.attr("uDat").and_then(|s| Some(s.to_owned())),
+            drag_data: row.attr("ddData").and_then(|s| Some(s.to_owned())),
+            drop_target_info: row.attr("ddDti").and_then(|s| Some(s.to_owned())),
+            parent_drop_target_info: row.attr("ddPDti").and_then(|s| Some(s.to_owned())),
+            selection_state: row
+                .attr("sst")
+                .and_then(|s| Some(s.into()))
+                .unwrap_or(SapTableSelectionState::default()),
+            row_type: row
+                .attr("rt")
+                .and_then(|s| Some(s.into()))
+                .unwrap_or(SapTableRowType::default()),
+        })
+    }
+
+    pub fn table_def(&self) -> ElementDef<'a, SapTable<'a>> {
+        self.table_def.clone()
+    }
+
+    pub fn row_index(&self) -> Option<u32> {
+        self.row_index
+    }
+
+    pub fn user_data(&self) -> Option<&str> {
+        self.user_data.as_ref().map(|x| x.as_str())
+    }
+
+    pub fn drag_data(&self) -> Option<&str> {
+        self.drag_data.as_ref().map(|x| x.as_str())
+    }
+
+    pub fn drop_target_info(&self) -> Option<&str> {
+        self.drop_target_info.as_ref().map(|x| x.as_str())
+    }
+
+    pub fn parent_drop_target_info(&self) -> Option<&str> {
+        self.parent_drop_target_info.as_ref().map(|x| x.as_str())
+    }
+
+    pub fn selection_state(&self) -> SapTableSelectionState {
+        self.selection_state
+    }
+
+    pub fn row_type(&self) -> SapTableRowType {
+        self.row_type
+    }
+}
+
+impl<'a> Deref for SapTableRow<'a> {
+    type Target = Vec<SapTableCellWrapper<'a>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cells
+    }
+}
+
+impl From<&str> for SapTableSelectionState {
+    fn from(s: &str) -> Self {
+        match s {
+            "4" => Self::NotSelectable,
+            "0" => Self::NotSelected,
+            "2" => Self::Selected,
+            "1" => Self::PrimarySelected,
+            _ => Self::None,
+        }
+    }
+}
+
+impl From<&str> for SapTableRowType {
+    fn from(s: &str) -> Self {
+        match s {
+            "1" => Self::Standard,
+            "2" => Self::Header,
+            "3" => Self::Filter,
+            "4" => Self::TopFixed,
+            "5" => Self::BottomFixed,
+            "6" => Self::Pivot,
+            _ => Self::Unspecified,
+        }
+    }
+}


### PR DESCRIPTION
# What’s in this pull request
- `SapTableBody` 를 자체 구조체로 변경하고 헤더 등 다양한 유틸리티 메소드 추가
- `SapTableRow` 구조체에 테이블 열에 담긴 추가 정보를 반영하고 셀 관련 유틸리티 메소드 추가