### PR TITLE
[refactor] 엘리먼트 LSData에 Option 제거

### DIFF
--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -145,11 +145,11 @@ impl<'a> CourseGrades {
             let semester = Self::semester_to_key(semester);
             let mut vec = Vec::with_capacity(2);
             let year_combobox = Self::PERIOD_YEAR.from_body(self.body())?;
-            if (|| Some(year_combobox.lsdata()?.key().as_ref()?.as_str()))() != Some(year) {
+            if (|| Some(year_combobox.lsdata().key().as_ref()?.as_str()))() != Some(year) {
                 vec.push(year_combobox.select(&year.to_string(), false)?);
             }
             let semester_combobox = Self::PERIOD_SEMESTER.from_body(self.body())?;
-            if (|| Some(semester_combobox.lsdata()?.key().as_ref()?.as_str()))() != Some(semester) {
+            if (|| Some(semester_combobox.lsdata().key().as_ref()?.as_str()))() != Some(semester) {
                 vec.push(semester_combobox.select(semester, false)?);
             }
             Result::<Vec<Event>, WebDynproError>::Ok(vec)
@@ -180,7 +180,7 @@ impl<'a> CourseGrades {
     }
 
     fn value_as_f32(field: InputField<'_>) -> Result<f32, WebDynproError> {
-        let Some(value) = field.lsdata().and_then(|lsdata| lsdata.value().as_ref()) else {
+        let Some(value) = field.lsdata().value().as_ref() else {
             return Err(ElementError::NoSuchData { element: field.id().to_string(), field: "value1".to_string() })?;
         };
         Ok(value.parse::<f32>().or(Err(ElementError::InvalidContent {

--- a/src/webdynpro/element/selection/combo_box.rs
+++ b/src/webdynpro/element/selection/combo_box.rs
@@ -56,13 +56,14 @@ impl<'a> ComboBox<'a> {
     }
 
     pub fn item_list_box(&self, body: &'a Body) -> Result<ListBoxWrapper<'a>, WebDynproError> {
-        let listbox_id = self
-            .lsdata()
-            .and_then(|lsdata| lsdata.item_list_box_id.as_ref())
-            .ok_or(ElementError::NoSuchData {
-                element: self.id().to_string(),
-                field: "item_list_box_id".to_string(),
-            })?;
+        let listbox_id =
+            self.lsdata()
+                .item_list_box_id
+                .as_ref()
+                .ok_or(ElementError::NoSuchData {
+                    element: self.id().to_string(),
+                    field: "item_list_box_id".to_string(),
+                })?;
         let selector = scraper::Selector::parse(format!(r#"[id="{}"]"#, listbox_id).as_str())
             .or(Err(ElementError::InvalidId(listbox_id.to_owned())))?;
         let elem = body

--- a/src/webdynpro/element/selection/list_box/mod.rs
+++ b/src/webdynpro/element/selection/list_box/mod.rs
@@ -30,13 +30,14 @@ macro_rules! def_listbox_subset {
 
             type ElementLSData = ListBoxLSData;
 
-            fn lsdata(&self) -> Option<&Self::ElementLSData> {
+            fn lsdata(&self) -> &Self::ElementLSData {
                 self.lsdata
                     .get_or_init(|| {
-                        let lsdata_obj = Self::lsdata_elem(self.element_ref).ok()?;
-                        serde_json::from_value::<Self::ElementLSData>(lsdata_obj).ok()
+                        let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
+                            return ListBoxLSData::default();
+                        };
+                        serde_json::from_value::<Self::ElementLSData>(lsdata_obj).unwrap_or(ListBoxLSData::default())
                     })
-                    .as_ref()
             }
 
             fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
@@ -105,7 +106,7 @@ macro_rules! def_listbox_subset {
 pub struct ListBox<'a> {
     id: Cow<'static, str>,
     element_ref: scraper::ElementRef<'a>,
-    lsdata: OnceCell<Option<ListBoxLSData>>,
+    lsdata: OnceCell<ListBoxLSData>,
     lsevents: OnceCell<Option<EventParameterMap>>,
     items: OnceCell<Vec<ListBoxItemWrapper<'a>>>,
 }

--- a/src/webdynpro/element/system/custom.rs
+++ b/src/webdynpro/element/system/custom.rs
@@ -70,8 +70,8 @@ impl<'a> Element<'a> for Custom {
 
     type ElementLSData = ();
 
-    fn lsdata(&self) -> Option<&Self::ElementLSData> {
-        None
+    fn lsdata(&self) -> &Self::ElementLSData {
+        &()
     }
 
     fn from_elem(

--- a/src/webdynpro/element/text/caption.rs
+++ b/src/webdynpro/element/text/caption.rs
@@ -39,11 +39,11 @@ impl<'a> Caption<'a> {
 
     pub fn text(&self) -> &str {
         self.text.get_or_init(|| {
-            if let Some(lsdata) = self.lsdata() {
-                lsdata.text().as_ref().unwrap_or(&"".to_string()).to_owned()
-            } else {
-                "".to_string()
-            }
+            self.lsdata()
+                .text()
+                .as_ref()
+                .unwrap_or(&"".to_string())
+                .to_owned()
         })
     }
 }

--- a/src/webdynpro/element/unknown.rs
+++ b/src/webdynpro/element/unknown.rs
@@ -13,25 +13,21 @@ pub struct Unknown<'a> {
     id: Cow<'static, str>,
     element_ref: scraper::ElementRef<'a>,
     ct: OnceCell<Option<String>>,
-    lsdata: OnceCell<Option<Value>>,
+    lsdata: OnceCell<Value>,
     lsevents: OnceCell<Option<EventParameterMap>>,
 }
 
 impl<'a> Element<'a> for Unknown<'a> {
     /// 실제로 사용하지 않는 가상의 Id
     const CONTROL_ID: &'static str = "_UNKNOWN";
-	/// 실제로 사용하지 않는 가상의 이름
+    /// 실제로 사용하지 않는 가상의 이름
     const ELEMENT_NAME: &'static str = "Unknown";
 
     type ElementLSData = Value;
 
-    fn lsdata(&self) -> Option<&Self::ElementLSData> {
+    fn lsdata(&self) -> &Self::ElementLSData {
         self.lsdata
-            .get_or_init(|| {
-                let lsdata_obj = Self::lsdata_elem(self.element_ref).ok()?;
-                serde_json::from_value::<Self::ElementLSData>(lsdata_obj).ok()
-            })
-            .as_ref()
+            .get_or_init(|| Self::lsdata_elem(self.element_ref).unwrap_or(Value::default()))
     }
 
     fn from_elem(
@@ -77,7 +73,7 @@ impl<'a> Unknown<'a> {
             lsevents: OnceCell::new(),
         }
     }
-	
+
     /// 이 엘리먼트의 실제 엘리먼트 Id를 반환합니다.
     pub fn ct(&self) -> Option<&String> {
         self.ct


### PR DESCRIPTION
# What’s in this pull request
- `Element::lsdata(&self)`의 리턴 타입을 `Option<&Self::ElementLSData>` 에서 `&Self::ElementLSData`로 변경