### PR TITLE
[feat] `WebDynproCommand` 객체를 이용한 클라이언트 제어

### DIFF
--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -574,7 +574,7 @@ impl<'a> SapTableCellWrapper<'a> {
     }
 }
 
-/// [`CourseGrades`](CourseGrades)에서 사용하는 데이터
+/// [`CourseGrades`]에서 사용하는 데이터
 pub mod model;
 
 #[cfg(test)]

--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -39,7 +39,7 @@ impl USaintApplication for CourseGrades {
         if client.name() != Self::APP_NAME {
             Err(RusaintError::InvalidClientError)
         } else {
-            Ok(CourseGrades { client })
+            Ok(Self { client })
         }
     }
 }

--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     define_elements,
     model::SemesterType,
     webdynpro::{
-        application::{body::Body, Application},
+        client::body::Body,
         element::{
             action::Button,
             complex::sap_table::{
@@ -20,16 +20,29 @@ use crate::{
         error::{BodyError, ElementError, WebDynproError},
         event::Event,
     },
+    RusaintError,
 };
 
 use self::model::{ClassGrade, CourseType, GradeSummary, SemesterGrade};
 
-use super::USaintApplication;
+use super::{USaintApplication, USaintClient};
 
-define_usaint_application!(
-    #[doc = "[학생 성적 조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMB3W0017)"]
-    pub struct CourseGrades<"ZCMB3W0017">
-);
+/// [학생 성적 조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMB3W0017)
+pub struct CourseGrades {
+    client: USaintClient,
+}
+
+impl USaintApplication for CourseGrades {
+    const APP_NAME: &'static str = "ZCMW3W0017";
+
+    fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(CourseGrades { client })
+        }
+    }
+}
 
 #[allow(unused)]
 impl<'a> CourseGrades {
@@ -74,7 +87,7 @@ impl<'a> CourseGrades {
 
     async fn close_popups(&mut self) -> Result<(), WebDynproError> {
         fn make_close_event(app: &CourseGrades) -> Option<Event> {
-            let body = app.body();
+            let body = app.client.body();
             let popup_selector =
                 scraper::Selector::parse(format!(r#"[ct="{}"]"#, PopupWindow::CONTROL_ID).as_str())
                     .unwrap();
@@ -89,7 +102,7 @@ impl<'a> CourseGrades {
             })
         }
         while let Some(event) = make_close_event(self) {
-            self.send_events(vec![event]).await?;
+            self.client.process_event(false, event).await?;
         }
         Ok(())
     }
@@ -117,17 +130,16 @@ impl<'a> CourseGrades {
         let select = {
             let course = Self::course_type_to_key(course);
             let mut vec = Vec::with_capacity(1);
-            let course_combobox = Self::PROGRESS_TYPE.from_body(self.body())?;
+            let course_combobox = Self::PROGRESS_TYPE.from_body(self.client.body())?;
             if (|| Some(course_combobox.lsdata().key()?.as_str()))() != Some(course) {
                 vec.push(course_combobox.select(&course.to_string(), false)?);
             }
             Result::<Vec<Event>, WebDynproError>::Ok(vec)
         }?;
-        if !select.is_empty() {
-            self.send_events(select).await
-        } else {
-            Ok(())
+        for event in select {
+            self.client.process_event(false, event).await?;
         }
+        Ok(())
     }
 
     async fn select_semester(
@@ -138,21 +150,20 @@ impl<'a> CourseGrades {
         let select = {
             let semester = Self::semester_to_key(semester);
             let mut vec = Vec::with_capacity(2);
-            let year_combobox = Self::PERIOD_YEAR.from_body(self.body())?;
+            let year_combobox = Self::PERIOD_YEAR.from_body(self.client.body())?;
             if (|| Some(year_combobox.lsdata().key()?.as_str()))() != Some(year) {
                 vec.push(year_combobox.select(&year.to_string(), false)?);
             }
-            let semester_combobox = Self::PERIOD_SEMESTER.from_body(self.body())?;
+            let semester_combobox = Self::PERIOD_SEMESTER.from_body(self.client.body())?;
             if (|| Some(semester_combobox.lsdata().key()?.as_str()))() != Some(semester) {
                 vec.push(semester_combobox.select(semester, false)?);
             }
             Result::<Vec<Event>, WebDynproError>::Ok(vec)
         }?;
-        if !select.is_empty() {
-            self.send_events(select).await
-        } else {
-            Ok(())
+        for event in select {
+            self.client.process_event(false, event).await?;
         }
+        Ok(())
     }
 
     fn row_to_string(row: &SapTableRow) -> Option<Vec<String>> {
@@ -209,7 +220,7 @@ impl<'a> CourseGrades {
     ) -> Result<GradeSummary, WebDynproError> {
         self.close_popups().await?;
         self.select_course(course_type).await?;
-        let body = self.body();
+        let body = self.client.body();
         let attempted_credits = Self::value_as_f32(Self::ATTM_CRD1.from_body(body)?)?;
         let earned_credits = Self::value_as_f32(Self::EARN_CRD1.from_body(body)?)?;
         let gpa = Self::value_as_f32(Self::GT_GPA1.from_body(body)?)?;
@@ -247,7 +258,7 @@ impl<'a> CourseGrades {
     ) -> Result<GradeSummary, WebDynproError> {
         self.close_popups().await?;
         self.select_course(course_type).await?;
-        let body = self.body();
+        let body = self.client.body();
         let attempted_credits = Self::value_as_f32(Self::ATTM_CRD2.from_body(body)?)?;
         let earned_credits = Self::value_as_f32(Self::EARN_CRD2.from_body(body)?)?;
         let gpa = Self::value_as_f32(Self::GT_GPA2.from_body(body)?)?;
@@ -292,7 +303,7 @@ impl<'a> CourseGrades {
         self.close_popups().await?;
         self.select_course(course_type).await?;
 
-        let table_elem = Self::GRADES_SUMMARY_TABLE.from_body(self.body())?;
+        let table_elem = Self::GRADES_SUMMARY_TABLE.from_body(self.client.body())?;
         let table = table_elem.table().ok_or(ElementError::NoSuchContent {
             element: table_elem.id().to_string(),
             content: "table".to_string(),
@@ -374,9 +385,9 @@ impl<'a> CourseGrades {
                 })
                 .collect::<Result<Vec<(String, f32)>, WebDynproError>>()
         };
-        let event = { open_button.from_body(self.body())?.press() }?;
-        self.send_events(vec![event]).await?;
-        let table = parse_table_in_popup(self.body())?;
+        let event = { open_button.from_body(self.client.body())?.press() }?;
+        self.client.process_event(false, event).await?;
+        let table = parse_table_in_popup(self.client.body())?;
         self.close_popups().await?;
         Ok(HashMap::from_iter(table))
     }
@@ -427,7 +438,7 @@ impl<'a> CourseGrades {
         self.select_course(course_type).await?;
         self.select_semester(year, semester).await?;
         let class_grades: Vec<(Option<String>, Vec<String>)> = {
-            let grade_table_elem = Self::GRADE_BY_CLASSES_TABLE.from_body(self.body())?;
+            let grade_table_elem = Self::GRADE_BY_CLASSES_TABLE.from_body(self.client.body())?;
             let iter = grade_table_elem
                 .table()
                 .ok_or(ElementError::NoSuchContent {
@@ -509,7 +520,7 @@ impl<'a> CourseGrades {
         self.close_popups().await?;
         self.select_course(course_type).await?;
         self.select_semester(year, semester).await?;
-        let table_elem = Self::GRADE_BY_CLASSES_TABLE.from_body(self.body())?;
+        let table_elem = Self::GRADE_BY_CLASSES_TABLE.from_body(self.client.body())?;
         let Some(table) = table_elem.table() else {
             return Err(ElementError::NoSuchContent {
                 element: table_elem.id().to_string(),
@@ -572,12 +583,9 @@ mod test {
     use std::sync::{Arc, OnceLock};
 
     use crate::{
-        application::{course_grades::CourseGrades, USaintApplicationBuilder},
+        application::{course_grades::CourseGrades, USaintClientBuilder},
         session::USaintSession,
-        webdynpro::{
-            application::Application,
-            element::{layout::PopupWindow, Element},
-        },
+        webdynpro::element::{layout::PopupWindow, Element},
     };
     use dotenv::dotenv;
 
@@ -602,13 +610,13 @@ mod test {
     #[tokio::test]
     async fn close_popups() {
         let session = get_session().await.unwrap();
-        let mut app = USaintApplicationBuilder::new()
+        let mut app = USaintClientBuilder::new()
             .session(session)
             .build_into::<CourseGrades>()
             .await
             .unwrap();
         app.close_popups().await.unwrap();
-        let body = app.body();
+        let body = app.client.body();
         let popup_selector =
             scraper::Selector::parse(format!(r#"[ct="{}"]"#, PopupWindow::CONTROL_ID).as_str())
                 .unwrap();

--- a/src/application/course_schedule.rs
+++ b/src/application/course_schedule.rs
@@ -175,7 +175,7 @@ mod test {
             .unwrap();
         app.load_edu().await.unwrap();
         let table = app.read_edu_raw().unwrap();
-        if let Some(table) = table.table() {
+        if let Ok(table) = table.table() {
             for row in table.with_header() {
                 print!("row: ");
                 for col in row.iter() {

--- a/src/application/course_schedule.rs
+++ b/src/application/course_schedule.rs
@@ -2,15 +2,30 @@ use crate::{
     define_elements,
     model::SemesterType,
     webdynpro::{
-        application::Application,
+        client::body::Body,
         element::{action::Button, complex::SapTable, layout::TabStrip, selection::ComboBox},
         error::WebDynproError,
     },
+    RusaintError,
 };
 
-use super::USaintApplication;
+use super::{USaintApplication, USaintClient};
 
-define_usaint_application!(pub struct CourseSchedule<"ZCMW2100">);
+pub struct CourseSchedule {
+    client: USaintClient,
+}
+
+impl USaintApplication for CourseSchedule {
+    const APP_NAME: &'static str = "ZCMW2100";
+
+    fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(Self { client })
+        }
+    }
+}
 
 #[allow(unused)]
 impl<'a> CourseSchedule {
@@ -38,7 +53,7 @@ impl<'a> CourseSchedule {
         period: SemesterType,
     ) -> Result<(), WebDynproError> {
         let events = {
-            let body = self.body();
+            let body = self.client.body();
             let period_year = Self::PERIOD_YEAR.from_body(body)?;
             let period_id = Self::PERIOD_ID.from_body(body)?;
             vec![
@@ -46,34 +61,40 @@ impl<'a> CourseSchedule {
                 period_id.select(Self::semester_to_key(period), false)?,
             ]
         };
-        self.send_events(events).await
+        for event in events {
+            self.client.process_event(false, event).await?;
+        }
+        Ok(())
     }
 
     pub async fn select_rows(&mut self, row: u32) -> Result<(), WebDynproError> {
         let events = {
-            let body = self.body();
+            let body = self.client.body();
             let table_rows = Self::TABLE_ROWS.from_body(body)?;
-            vec![table_rows.select(row.to_string().as_str(), false)?]
+            table_rows.select(row.to_string().as_str(), false)?
         };
-        self.send_events(events).await
+        self.client.process_event(false, events).await?;
+        Ok(())
     }
 
     pub async fn select_edu(&mut self) -> Result<(), WebDynproError> {
         let events = {
-            let body = self.body();
+            let body = self.client.body();
             let tab_strip = Self::TABSTRIP.from_body(body)?;
-            vec![tab_strip.tab_select("ZCMW2100.ID_0001:VIW_MAIN.TAB_EDU", 4, 0)?]
+            tab_strip.tab_select("ZCMW2100.ID_0001:VIW_MAIN.TAB_EDU", 4, 0)?
         };
-        self.send_events(events).await
+        self.client.process_event(false, events).await?;
+        Ok(())
     }
 
     async fn search_edu(&mut self) -> Result<(), WebDynproError> {
         let events = {
-            let body = self.body();
+            let body = self.client.body();
             let button_edu = Self::BUTTON_EDU.from_body(body)?;
-            vec![button_edu.press()?]
+            button_edu.press()?
         };
-        self.send_events(events).await
+        self.client.process_event(false, events).await?;
+        Ok(())
     }
 
     pub async fn load_edu(&mut self) -> Result<(), WebDynproError> {
@@ -83,28 +104,29 @@ impl<'a> CourseSchedule {
     }
 
     pub fn read_edu_raw(&self) -> Result<SapTable, WebDynproError> {
-        let main_table = Self::MAIN_TABLE.from_body(self.body())?;
+        let main_table = Self::MAIN_TABLE.from_body(self.client.body())?;
         Ok(main_table)
+    }
+
+    fn body(&self) -> &Body {
+        self.client.body()
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::{
-        application::{course_schedule::CourseSchedule, USaintApplicationBuilder},
-        webdynpro::{
-            application::Application,
-            element::{
-                complex::sap_table::cell::{SapTableCell, SapTableCellWrapper},
-                selection::list_box::{item::ListBoxItemWrapper, ListBoxWrapper},
-                ElementWrapper,
-            },
+        application::{course_schedule::CourseSchedule, USaintClientBuilder},
+        webdynpro::element::{
+            complex::sap_table::cell::{SapTableCell, SapTableCellWrapper},
+            selection::list_box::{item::ListBoxItemWrapper, ListBoxWrapper},
+            ElementWrapper,
         },
     };
 
     #[tokio::test]
     async fn examine_elements() {
-        let app = USaintApplicationBuilder::new()
+        let app = USaintClientBuilder::new()
             .build_into::<CourseSchedule>()
             .await
             .unwrap();
@@ -119,7 +141,7 @@ mod test {
 
     #[tokio::test]
     async fn combobox_items() {
-        let app = USaintApplicationBuilder::new()
+        let app = USaintClientBuilder::new()
             .build_into::<CourseSchedule>()
             .await
             .unwrap();
@@ -147,7 +169,7 @@ mod test {
 
     #[tokio::test]
     async fn table_test() {
-        let mut app = USaintApplicationBuilder::new()
+        let mut app = USaintClientBuilder::new()
             .build_into::<CourseSchedule>()
             .await
             .unwrap();

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -141,5 +141,5 @@ impl USaintClientBuilder {
 }
 /// 학생 성적 조회: [`CourseGrades`](course_grades::CourseGrades)
 pub mod course_grades;
-// mod course_schedule;
-// mod student_information;
+mod course_schedule;
+mod student_information;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -5,13 +5,10 @@ use crate::{
     session::USaintSession,
     utils::DEFAULT_USER_AGENT,
     webdynpro::{
-        client::{body::Body, EventProcessResult, WebDynproClient, WebDynproClientBuilder},
-        element::{
+        client::{body::Body, EventProcessResult, WebDynproClient, WebDynproClientBuilder}, command::WebDynproCommand, element::{
             define_elements,
             system::{ClientInspector, Custom, CustomClientInfo, LoadingPlaceholder},
-        },
-        error::WebDynproError,
-        event::Event,
+        }, error::WebDynproError, event::Event
     },
     RusaintError,
 };
@@ -56,6 +53,15 @@ impl<'a> USaintClient {
     pub fn client_url(&self) -> String {
         self.0.client_url()
     }
+
+    /// WebDynpro 클라이언트에 명령을 전송합니다.
+    pub async fn send<T: WebDynproCommand>(
+        &mut self,
+        command: T,
+    ) -> Result<T::Result, WebDynproError> {
+        self.0.send(command).await
+    }
+
 
     /// 이벤트를 처리합니다. [`process_event()`](crate::webdynpro::client::WebDynproClient::process_event)를 참조하세요.
     pub async fn process_event(

--- a/src/application/student_information.rs
+++ b/src/application/student_information.rs
@@ -1,6 +1,28 @@
-use super::USaintApplication;
+use crate::{webdynpro::client::body::Body, RusaintError};
 
-define_usaint_application!(pub struct StudentInformation<"ZCMW1001n">);
+use super::{USaintApplication, USaintClient};
+
+pub struct StudentInformation {
+    client: USaintClient,
+}
+
+impl USaintApplication for StudentInformation {
+    const APP_NAME: &'static str = "ZCMW2100";
+
+    fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(Self { client })
+        }
+    }
+}
+
+impl StudentInformation {
+    fn body(&self) -> &Body {
+        self.client.body()
+    }
+}
 
 #[cfg(test)]
 mod test {
@@ -8,9 +30,9 @@ mod test {
     use std::sync::{Arc, OnceLock};
 
     use crate::{
-        application::{student_information::StudentInformation, USaintApplicationBuilder},
+        application::{student_information::StudentInformation, USaintClientBuilder},
         session::USaintSession,
-        webdynpro::{application::Application, element::ElementWrapper},
+        webdynpro::element::ElementWrapper,
     };
     use dotenv::dotenv;
 
@@ -35,7 +57,7 @@ mod test {
     #[tokio::test]
     async fn examine_elements() {
         let session = get_session().await.unwrap();
-        let app = USaintApplicationBuilder::new()
+        let app = USaintClientBuilder::new()
             .session(session)
             .build_into::<StudentInformation>()
             .await

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -8,6 +8,9 @@ pub enum RusaintError {
     /// 내부 WebDynpro 엔진 오류
     #[error("WebDynpro engine error: {0}")]
     WebDynproError(#[from] WebDynproError),
+    /// 애플리케이션의 기반 클라이언트 불일치 오류
+    #[error("Invalid Client for target application")]
+    InvalidClientError,
     /// 숭실대학교 SSO 로그인 오류
     #[error("Failed to login with ssu sso: {0}")]
     SsoLoginError(#[from] SsuSsoError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```no_run
 //! use rusaint::application::course_grades::{CourseGrades, model::CourseType, model::SemesterGrade};
-//! use rusaint::application::USaintApplicationBuilder;
+//! use rusaint::application::USaintClientBuilder;
 //! use rusaint::webdynpro::element::Element;
 //! use rusaint::RusaintError;
 //! use std::sync::Arc;
@@ -37,7 +37,7 @@
 //! async fn print_grades() -> Result<(), RusaintError> {
 //!     // USaintSession::with_token(id: &str, token: &str) 을 이용하여 비밀번호 없이 SSO 토큰으로 로그인 할 수 있음
 //!     let session = Arc::new(USaintSession::with_password("20211561", "password").await?);
-//!     let mut app = USaintApplicationBuilder::new().session(session).build_into::<CourseGrades>().await?;
+//!     let mut app = USaintClientBuilder::new().session(session).build_into::<CourseGrades>().await?;
 //!     let grades: Vec<SemesterGrade> = app.semesters(CourseType::Bachelor).await?;
 //!     for grade in grades {
 //!         println!("{:?}", grade);

--- a/src/webdynpro/client/mod.rs
+++ b/src/webdynpro/client/mod.rs
@@ -286,8 +286,11 @@ pub(crate) struct SapSsrClient {
     use_beacon: bool,
 }
 
+/// 전달받은 이벤트가 어떻게 처리되었는지 표현합니다.
 pub enum EventProcessResult {
+    /// 전달받은 이벤트가 큐에 추가되었을 경우
     Enqueued,
+    /// 전달받은 이벤트가 큐에 추가된 후 서버에 전송되었을 경우
     Sent,
 }
 

--- a/src/webdynpro/command/element/action.rs
+++ b/src/webdynpro/command/element/action.rs
@@ -1,0 +1,21 @@
+use crate::webdynpro::{
+    client::EventProcessResult,
+    command::WebDynproCommand,
+    element::{action::Button, ElementDef}, error::WebDynproError,
+};
+
+pub struct ButtonPressCommand<'a> {
+    element_def: ElementDef<'a, Button<'a>>,
+}
+
+impl<'a> WebDynproCommand for ButtonPressCommand<'a> {
+    type Result = EventProcessResult;
+
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        let event = (&self.element_def).from_body(client.body())?.press()?;
+        client.process_event(false, event).await
+    }
+}

--- a/src/webdynpro/command/element/action.rs
+++ b/src/webdynpro/command/element/action.rs
@@ -4,8 +4,18 @@ use crate::webdynpro::{
     element::{action::Button, ElementDef}, error::WebDynproError,
 };
 
+/// 주어진 [`Button`]을 누름
 pub struct ButtonPressCommand<'a> {
     element_def: ElementDef<'a, Button<'a>>,
+}
+
+impl<'a> ButtonPressCommand<'a> {
+  /// 새로운 명령 객체를 생성합니다.
+  pub fn new(element_def: ElementDef<'a, Button<'a>>) -> ButtonPressCommand<'a> {
+    ButtonPressCommand {
+      element_def
+    }
+  }
 }
 
 impl<'a> WebDynproCommand for ButtonPressCommand<'a> {

--- a/src/webdynpro/command/element/mod.rs
+++ b/src/webdynpro/command/element/mod.rs
@@ -3,3 +3,6 @@ pub mod action;
 
 /// 선택 분류의 엘리먼트([`ListBox`], [`ComboBox`])를 위한 명령
 pub mod selection;
+
+/// 복합 분류의 엘리먼트([`SapTable`])를 위한 명령
+pub mod complex;

--- a/src/webdynpro/command/element/mod.rs
+++ b/src/webdynpro/command/element/mod.rs
@@ -1,0 +1,5 @@
+/// 액션 분류의 엘리먼트([`Button`], [`Link`])를 위한 명령
+pub mod action;
+
+/// 선택 분류의 엘리먼트([`ListBox`], [`ComboBox`])를 위한 명령
+pub mod selection;

--- a/src/webdynpro/command/element/selection.rs
+++ b/src/webdynpro/command/element/selection.rs
@@ -8,6 +8,7 @@ use crate::webdynpro::{
     error::WebDynproError,
 };
 
+/// [`ComboBox`]의 선택지를 선택하도록 함
 pub struct ComboBoxSelectCommand<'a> {
     element_def: ElementDef<'a, ComboBox<'a>>,
     key: String,
@@ -15,6 +16,7 @@ pub struct ComboBoxSelectCommand<'a> {
 }
 
 impl<'a> ComboBoxSelectCommand<'a> {
+  /// 새로운 명령 객체를 생성합니다.
   pub fn new(element_def: ElementDef<'a, ComboBox<'a>>, key: &str, by_enter: bool) -> ComboBoxSelectCommand<'a> {
     Self {
       element_def,
@@ -39,11 +41,13 @@ impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
     }
 }
 
+/// [`ComboBoxLSData`]를 반환
 pub struct ReadComboBoxLSDataCommand<'a> {
     element_def: ElementDef<'a, ComboBox<'a>>,
 }
 
 impl<'a> ReadComboBoxLSDataCommand<'a> {
+  /// 새로운 명령 객체를 생성합니다.
     pub fn new(element_def: ElementDef<'a, ComboBox<'a>>) -> ReadComboBoxLSDataCommand<'a> {
         Self { element_def }
     }

--- a/src/webdynpro/command/element/selection.rs
+++ b/src/webdynpro/command/element/selection.rs
@@ -1,17 +1,62 @@
-use crate::webdynpro::{client::EventProcessResult, command::WebDynproCommand, element::{selection::ComboBox, ElementDef}, error::WebDynproError};
-
+use crate::webdynpro::{
+    client::EventProcessResult,
+    command::WebDynproCommand,
+    element::{
+        selection::{ComboBox, ComboBoxLSData},
+        Element, ElementDef,
+    },
+    error::WebDynproError,
+};
 
 pub struct ComboBoxSelectCommand<'a> {
-  element_def: ElementDef<'a, ComboBox<'a>>,
-  key: String,
-  by_enter: bool
+    element_def: ElementDef<'a, ComboBox<'a>>,
+    key: String,
+    by_enter: bool,
+}
+
+impl<'a> ComboBoxSelectCommand<'a> {
+  pub fn new(element_def: ElementDef<'a, ComboBox<'a>>, key: &str, by_enter: bool) -> ComboBoxSelectCommand<'a> {
+    Self {
+      element_def,
+      key: key.to_string(),
+      by_enter
+    }
+  }
 }
 
 impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
-  type Result = EventProcessResult;
+    type Result = EventProcessResult;
 
-  async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
-      let event = self.element_def.from_body(client.body())?.select(&self.key, self.by_enter)?;
-      client.process_event(false, event).await
-  }
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        let event = self
+            .element_def
+            .from_body(client.body())?
+            .select(&self.key, self.by_enter)?;
+        client.process_event(false, event).await
+    }
+}
+
+pub struct ReadComboBoxLSDataCommand<'a> {
+    element_def: ElementDef<'a, ComboBox<'a>>,
+}
+
+impl<'a> ReadComboBoxLSDataCommand<'a> {
+    pub fn new(element_def: ElementDef<'a, ComboBox<'a>>) -> ReadComboBoxLSDataCommand<'a> {
+        Self { element_def }
+    }
+}
+
+impl<'a> WebDynproCommand for ReadComboBoxLSDataCommand<'a> {
+    type Result = ComboBoxLSData;
+
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        let lsdata = self.element_def.from_body(client.body())?.lsdata().clone();
+        Ok(lsdata)
+    }
 }

--- a/src/webdynpro/command/element/selection.rs
+++ b/src/webdynpro/command/element/selection.rs
@@ -1,0 +1,17 @@
+use crate::webdynpro::{client::EventProcessResult, command::WebDynproCommand, element::{selection::ComboBox, ElementDef}, error::WebDynproError};
+
+
+pub struct ComboBoxSelectCommand<'a> {
+  element_def: ElementDef<'a, ComboBox<'a>>,
+  key: String,
+  by_enter: bool
+}
+
+impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
+  type Result = EventProcessResult;
+
+  async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
+      let event = self.element_def.from_body(client.body())?.select(&self.key, self.by_enter)?;
+      client.process_event(false, event).await
+  }
+}

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -6,16 +6,11 @@ use super::{
 /// WebDynpro 클라이언트를 조작하는 명령
 pub trait WebDynproCommand {
     /// 해당 명령이 반환할 결과
-    type Result: WebDynproCommandResult;
+    type Result;
 
     /// 해당 명령을 주어진 클라이언트에 대해 실행합니다.
     async fn dispatch(&self, client: &mut WebDynproClient) -> Result<Self::Result, WebDynproError>;
 }
-
-/// [`WebDynproCommand`]의 결과에 대한 마커 트레이트
-pub trait WebDynproCommandResult {}
-
-impl WebDynproCommandResult for EventProcessResult {}
 
 
 /// 엘리먼트 관련 명령

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -3,12 +3,16 @@ use super::{
     error::WebDynproError,
 };
 
+/// WebDynpro 클라이언트를 조작하는 명령
 pub trait WebDynproCommand {
+    /// 해당 명령이 반환할 결과
     type Result: WebDynproCommandResult;
 
+    /// 해당 명령을 주어진 클라이언트에 대해 실행합니다.
     async fn dispatch(&self, client: &mut WebDynproClient) -> Result<Self::Result, WebDynproError>;
 }
 
+/// [`WebDynproCommand`]의 결과에 대한 마커 트레이트
 pub trait WebDynproCommandResult {}
 
 impl WebDynproCommandResult for EventProcessResult {}

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -1,9 +1,14 @@
-use super::{client::WebDynproClient, error::WebDynproError};
+use super::{
+    client::{EventProcessResult, WebDynproClient},
+    error::WebDynproError,
+};
 
-pub(crate) trait WebDynproCommand {
+pub trait WebDynproCommand {
     type Result: WebDynproCommandResult;
 
     async fn dispatch(&self, client: &mut WebDynproClient) -> Result<Self::Result, WebDynproError>;
 }
 
-pub(crate) trait WebDynproCommandResult {}
+pub trait WebDynproCommandResult {}
+
+impl WebDynproCommandResult for EventProcessResult {}

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -16,3 +16,7 @@ pub trait WebDynproCommand {
 pub trait WebDynproCommandResult {}
 
 impl WebDynproCommandResult for EventProcessResult {}
+
+
+/// 엘리먼트 관련 명령
+pub mod element;

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -1,0 +1,9 @@
+use super::{client::WebDynproClient, error::WebDynproError};
+
+pub(crate) trait WebDynproCommand {
+    type Result: WebDynproCommandResult;
+
+    async fn dispatch(&self, client: &mut WebDynproClient) -> Result<Self::Result, WebDynproError>;
+}
+
+pub(crate) trait WebDynproCommandResult {}

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -1,7 +1,4 @@
-use super::{
-    client::{EventProcessResult, WebDynproClient},
-    error::WebDynproError,
-};
+use super::{client::WebDynproClient, error::WebDynproError};
 
 /// WebDynpro 클라이언트를 조작하는 명령
 pub trait WebDynproCommand {
@@ -11,7 +8,6 @@ pub trait WebDynproCommand {
     /// 해당 명령을 주어진 클라이언트에 대해 실행합니다.
     async fn dispatch(&self, client: &mut WebDynproClient) -> Result<Self::Result, WebDynproError>;
 }
-
 
 /// 엘리먼트 관련 명령
 pub mod element;

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use crate::webdynpro::{
-    client::EventProcessResult, command::WebDynproCommand, element::{
-        define_element_interactable, property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility}, ElementDef, Interactable
+    element::{
+        define_element_interactable, property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility}, Interactable
     }, error::WebDynproError, event::Event
 };
 
@@ -118,19 +118,5 @@ impl<'a> Button<'a> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("Press".to_string(), parameters)
-    }
-}
-
-
-pub struct ButtonPressCommand<'a> {
-    element_def: ElementDef<'a, Button<'a>>
-}
-
-impl<'a> WebDynproCommand for ButtonPressCommand<'a> {
-    type Result = EventProcessResult;
-
-    async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
-        let event = (&self.element_def).from_body(client.body())?.press()?;
-        client.process_event(false, event).await
     }
 }

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -122,16 +122,15 @@ impl<'a> Button<'a> {
 }
 
 
-pub struct ButtonPressCommand {
-    id: String
+pub struct ButtonPressCommand<'a> {
+    element_def: ElementDef<'a, Button<'a>>
 }
 
-impl WebDynproCommand for ButtonPressCommand {
+impl<'a> WebDynproCommand for ButtonPressCommand<'a> {
     type Result = EventProcessResult;
 
     async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
-        let element_def: ElementDef<'_, Button<'_>> = ElementDef::new_dynamic(self.id);
-        let event = element_def.from_body(client.body())?.press()?;
-        client.process_event(false, event)
+        let event = (&self.element_def).from_body(client.body())?.press()?;
+        client.process_event(false, event).await
     }
 }

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -1,13 +1,9 @@
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use crate::webdynpro::{
-    element::{
-        define_element_interactable,
-        property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility},
-        Interactable,
-    },
-    error::WebDynproError,
-    event::Event,
+    command::WebDynproCommand, element::{
+        define_element_interactable, property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility}, ElementDef, Interactable
+    }, error::WebDynproError, event::Event
 };
 
 use super::{ButtonDesign, ButtonInteractionBehaviour, ButtonType};
@@ -122,5 +118,20 @@ impl<'a> Button<'a> {
         let mut parameters: HashMap<String, String> = HashMap::new();
         parameters.insert("Id".to_string(), self.id.clone().to_string());
         self.fire_event("Press".to_string(), parameters)
+    }
+}
+
+
+pub struct ButtonPressCommand {
+    id: String
+}
+
+impl WebDynproCommand for ButtonPressCommand {
+    type Result = ();
+
+    async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
+        let element_def: ElementDef<'_, Button<'_>> = ElementDef::new_dynamic(self.id);
+        let element = element_def.from_body(client.body())?;
+        client.send_events(vec![element.press()?]).await
     }
 }

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use crate::webdynpro::{
-    command::WebDynproCommand, element::{
+    client::EventProcessResult, command::WebDynproCommand, element::{
         define_element_interactable, property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility}, ElementDef, Interactable
     }, error::WebDynproError, event::Event
 };
@@ -127,11 +127,11 @@ pub struct ButtonPressCommand {
 }
 
 impl WebDynproCommand for ButtonPressCommand {
-    type Result = ();
+    type Result = EventProcessResult;
 
     async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
         let element_def: ElementDef<'_, Button<'_>> = ElementDef::new_dynamic(self.id);
-        let element = element_def.from_body(client.body())?;
-        client.send_events(vec![element.press()?]).await
+        let event = element_def.from_body(client.body())?.press()?;
+        client.process_event(false, event)
     }
 }

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -2,8 +2,12 @@ use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use crate::webdynpro::{
     element::{
-        define_element_interactable, property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility}, Interactable
-    }, error::WebDynproError, event::Event
+        define_element_interactable,
+        property::{ContentVisibility, HotkeyValue, SemanticColor, TextDesign, Visibility},
+        Interactable,
+    },
+    error::WebDynproError,
+    event::Event,
 };
 
 use super::{ButtonDesign, ButtonInteractionBehaviour, ButtonType};
@@ -13,7 +17,7 @@ pub mod property {
 
     /// 버튼의 외형 종류
     #[allow(missing_docs)]
-    #[derive(Deserialize, Debug)]
+    #[derive(Clone, Deserialize, Debug)]
     #[serde(rename_all = "UPPERCASE")]
     pub enum ButtonDesign {
         Emphasized,
@@ -28,7 +32,7 @@ pub mod property {
 
     /// 버튼의 동작 분류
     #[allow(missing_docs)]
-    #[derive(Deserialize, Debug)]
+    #[derive(Clone, Deserialize, Debug)]
     #[serde(rename_all = "UPPERCASE")]
     pub enum ButtonType {
         None,
@@ -54,7 +58,7 @@ pub mod property {
 
     /// 버튼의 상호작용 동작
     #[allow(missing_docs)]
-    #[derive(Deserialize, Debug)]
+    #[derive(Clone, Deserialize, Debug)]
     #[serde(rename_all = "UPPERCASE")]
     pub enum ButtonInteractionBehaviour {
         Push,

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -37,8 +37,14 @@ impl<'a> SapTable<'a> {
     }
 
     /// 테이블 내부 컨텐츠를 반환합니다.
-    pub fn table(&self) -> Option<&SapTableBody<'a>> {
-        self.table.get_or_init(|| self.parse_table().ok()).as_ref()
+    pub fn table(&self) -> Result<&SapTableBody<'a>, WebDynproError> {
+        self.table
+            .get_or_init(|| self.parse_table().ok())
+            .as_ref()
+            .ok_or(WebDynproError::Element(ElementError::NoSuchContent {
+                element: self.id.to_string(),
+                content: "Table body".to_string(),
+            }))
     }
 
     fn parse_table(&self) -> Result<SapTableBody<'a>, WebDynproError> {
@@ -62,11 +68,11 @@ impl<'a> SapTable<'a> {
         )
         .or(Err(BodyError::InvalidSelector))?;
         let Some(tbody) = element.select(&tbody_selector).next() else {
-                return Err(ElementError::NoSuchContent {
-                    element: self.id.clone().into_owned(),
-                    content: "Table body".to_string(),
-                })?;
-            };
+            return Err(ElementError::NoSuchContent {
+                element: self.id.clone().into_owned(),
+                content: "Table body".to_string(),
+            })?;
+        };
         Ok(SapTableBody::new(def, tbody)?)
     }
 

--- a/src/webdynpro/element/complex/sap_table/property.rs
+++ b/src/webdynpro/element/complex/sap_table/property.rs
@@ -27,7 +27,7 @@ impl ToString for AccessType {
 
 /// 테이블 셀의 형태 종류
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SapTableCellDesign {
     Standard,
@@ -276,7 +276,7 @@ pub enum SapTableCellDesign {
 
 /// 테이블 셀의 종류
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SapTableCellType {
     Text,
@@ -290,7 +290,7 @@ pub enum SapTableCellType {
 
 /// [`SapTableHeaderCell`](super::cell::SapTableHeaderCell)의 형태 종류
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SapTableHeaderCellDesign {
     Level1Header,
@@ -300,7 +300,7 @@ pub enum SapTableHeaderCellDesign {
 
 /// [`SapTableHeaderCell`](super::cell::SapTableHeaderCell)의 종류
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SapTableHeaderCellType {
     Standard,
@@ -309,7 +309,7 @@ pub enum SapTableHeaderCellType {
 
 /// [`SapTableHierarchicalCell`](super::cell::SapTableHierarchicalCell)의 상태
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SapTableHierarchicalCellStatus {
     None,
@@ -339,7 +339,7 @@ pub enum SapTableSelectionState {
 
 /// 테이블 내부 행의 전체적인 선택 상태
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SapTableRowSelectionMassState {
     None,
@@ -364,7 +364,7 @@ pub enum SapTableRowType {
 
 /// 테이블 열 선택시의 액션
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SapTableSelectionColumnAction {
     None,

--- a/src/webdynpro/element/graphic/image.rs
+++ b/src/webdynpro/element/graphic/image.rs
@@ -12,7 +12,7 @@ pub mod property {
 
     /// 이미지 표시 모드
     #[allow(missing_docs)]
-    #[derive(Deserialize, Debug)]
+    #[derive(Clone, Deserialize, Debug)]
     #[serde(rename_all = "UPPERCASE")]
     pub enum ItsDisplayMode {
         Normal,

--- a/src/webdynpro/element/layout/scrollbar.rs
+++ b/src/webdynpro/element/layout/scrollbar.rs
@@ -7,7 +7,7 @@ use self::property::ScrollDirection;
 pub mod property {
     use serde::Deserialize;
 
-    #[derive(Deserialize, Debug)]
+    #[derive(Clone, Deserialize, Debug)]
     #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
     pub enum ScrollDirection {
         Vertical,

--- a/src/webdynpro/element/layout/tray.rs
+++ b/src/webdynpro/element/layout/tray.rs
@@ -9,7 +9,7 @@ use self::property::TrayDesign;
 
 pub mod property {
     use serde::Deserialize;
-    #[derive(Deserialize, Debug)]
+    #[derive(Clone, Deserialize, Debug)]
     #[serde(rename_all = "UPPERCASE")]
     pub enum TrayDesign {
         Transparent,

--- a/src/webdynpro/element/mod.rs
+++ b/src/webdynpro/element/mod.rs
@@ -42,7 +42,7 @@ macro_rules! define_lsdata {
         }
     } => {
         $(#[$lsdata_outer])*
-        #[derive(serde::Deserialize, Debug, Default)]
+        #[derive(Clone, serde::Deserialize, Debug, Default)]
         #[allow(unused)]
         pub struct $lsdata {
             $(

--- a/src/webdynpro/element/mod.rs
+++ b/src/webdynpro/element/mod.rs
@@ -105,7 +105,7 @@ macro_rules! define_element_base {
             }
 
             fn from_elem(
-                elem_def: $crate::webdynpro::element::ElementDef<'a, Self>,
+                elem_def: &$crate::webdynpro::element::ElementDef<'a, Self>,
                 element: scraper::ElementRef<'a>,
             ) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
                 Ok(Self::new(elem_def.id.to_owned(), element))
@@ -345,12 +345,12 @@ where T: Element<'a>
     }
 
 	/// [`Body`]에서 엘리먼트를 불러옵니다.
-    pub fn from_body(self, body: &'a Body) -> Result<T, WebDynproError> {
+    pub fn from_body(&self, body: &'a Body) -> Result<T, WebDynproError> {
         T::from_body(self, body)
     }
 	
     /// `scraper::ElementRef`에서 엘리먼트를 불러옵니다.
-    pub fn from_elem(self, element: scraper::ElementRef<'a>) -> Result<T, WebDynproError> {
+    pub fn from_elem(&self, element: scraper::ElementRef<'a>) -> Result<T, WebDynproError> {
         T::from_elem(self, element)
     }
 }
@@ -422,7 +422,7 @@ pub trait Element<'a>: Sized {
     }
 
 	/// 엘리먼트 정의와 [`Body`]에서 엘리먼트를 가져옵니다.
-    fn from_body(elem_def: ElementDef<'a, Self>, body: &'a Body) -> Result<Self, WebDynproError> {
+    fn from_body(elem_def: &ElementDef<'a, Self>, body: &'a Body) -> Result<Self, WebDynproError> {
         let selector = &elem_def.selector().or(Err(BodyError::InvalidSelector))?;
         let element = body
             .document()
@@ -433,7 +433,7 @@ pub trait Element<'a>: Sized {
     }
 
 	/// 엘리먼트 정의와 [`scraper::ElementRef`]에서 엘리먼트를 가져옵니다.
-    fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, WebDynproError>;
+    fn from_elem(elem_def: &ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, WebDynproError>;
 
 	/// 엘리먼트의 자식 엘리먼트를 가져옵니다.
     fn children_elem(root: scraper::ElementRef<'a>) -> Vec<ElementWrapper<'a>> {

--- a/src/webdynpro/element/property/mod.rs
+++ b/src/webdynpro/element/property/mod.rs
@@ -4,7 +4,7 @@ use super::complex::sap_table::property::SapTableCellDesign;
 
 /// 텍스트 형태 종류
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum TextDesign {
     Standard,
@@ -12,7 +12,7 @@ pub enum TextDesign {
 }
 /// 텍스트 방향
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum TextDirection {
     Ltr,
@@ -21,7 +21,7 @@ pub enum TextDirection {
 }
 /// 엘리먼트의 가시성
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Visibility {
     Visible,
@@ -31,7 +31,7 @@ pub enum Visibility {
 }
 /// 컨텐츠 가시성
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ContentVisibility {
     All,
@@ -41,7 +41,7 @@ pub enum ContentVisibility {
 
 /// 단축키 값
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HotkeyValue {
     None,
@@ -200,7 +200,7 @@ pub enum HotkeyValue {
 
 /// 수평 텍스트 정렬
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum HorizontalTextAlign {
     Center,
@@ -211,7 +211,7 @@ pub enum HorizontalTextAlign {
 
 /// 엘리먼트가 잠겼을 때의 형태
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum LockedDesign {
     Transparent,
@@ -226,7 +226,7 @@ pub enum LockedDesign {
 
 /// 윈도우 모드
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Mode {
     Modal,
@@ -236,7 +236,7 @@ pub enum Mode {
 
 /// 스크롤 모드
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ScrollingMode {
     Auto,
@@ -254,7 +254,7 @@ pub type SemanticColor = SapTableCellDesign;
 
 /// 정렬 상태
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SortState {
     Disabled,
@@ -265,7 +265,7 @@ pub enum SortState {
 
 /// 수직 텍스트 정렬
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum VerticalTextAlign {
     Middle,
@@ -276,7 +276,7 @@ pub enum VerticalTextAlign {
 
 /// 퀵뷰 윈도우 디자인
 #[allow(missing_docs)]
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum QuickViewDesign {
     Standard,

--- a/src/webdynpro/element/selection/combo_box.rs
+++ b/src/webdynpro/element/selection/combo_box.rs
@@ -1,10 +1,12 @@
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
+use crate::webdynpro::client::EventProcessResult;
+use crate::webdynpro::command::WebDynproCommand;
 use crate::webdynpro::error::{BodyError, WebDynproError};
 use crate::webdynpro::{client::body::Body, error::ElementError, event::Event};
 
 use crate::webdynpro::element::{
-    define_element_interactable, Element, ElementWrapper, Interactable,
+    define_element_interactable, Element, ElementDef, ElementWrapper, Interactable
 };
 
 use super::list_box::ListBoxWrapper;
@@ -87,5 +89,21 @@ impl<'a> ComboBox<'a> {
         parameters.insert("Key".to_string(), key.to_string());
         parameters.insert("ByEnter".to_string(), by_enter.to_string());
         self.fire_event("Select".to_string(), parameters)
+    }
+}
+
+
+pub struct ComboBoxSelectCommand<'a> {
+    element_def: ElementDef<'a, ComboBox<'a>>,
+    key: String,
+    by_enter: bool
+}
+
+impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
+    type Result = EventProcessResult;
+
+    async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
+        let event = self.element_def.from_body(client.body())?.select(&self.key, self.by_enter)?;
+        client.process_event(false, event).await
     }
 }

--- a/src/webdynpro/element/selection/combo_box.rs
+++ b/src/webdynpro/element/selection/combo_box.rs
@@ -1,12 +1,11 @@
 use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
-use crate::webdynpro::client::EventProcessResult;
-use crate::webdynpro::command::WebDynproCommand;
+
 use crate::webdynpro::error::{BodyError, WebDynproError};
 use crate::webdynpro::{client::body::Body, error::ElementError, event::Event};
 
 use crate::webdynpro::element::{
-    define_element_interactable, Element, ElementDef, ElementWrapper, Interactable
+    define_element_interactable, Element, ElementWrapper, Interactable
 };
 
 use super::list_box::ListBoxWrapper;
@@ -89,21 +88,5 @@ impl<'a> ComboBox<'a> {
         parameters.insert("Key".to_string(), key.to_string());
         parameters.insert("ByEnter".to_string(), by_enter.to_string());
         self.fire_event("Select".to_string(), parameters)
-    }
-}
-
-
-pub struct ComboBoxSelectCommand<'a> {
-    element_def: ElementDef<'a, ComboBox<'a>>,
-    key: String,
-    by_enter: bool
-}
-
-impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
-    type Result = EventProcessResult;
-
-    async fn dispatch(&self, client: &mut crate::webdynpro::client::WebDynproClient) -> Result<Self::Result, WebDynproError> {
-        let event = self.element_def.from_body(client.body())?.select(&self.key, self.by_enter)?;
-        client.process_event(false, event).await
     }
 }

--- a/src/webdynpro/element/selection/list_box/mod.rs
+++ b/src/webdynpro/element/selection/list_box/mod.rs
@@ -38,7 +38,7 @@ macro_rules! def_listbox_subset {
                     })
             }
 
-            fn from_elem(elem_def: ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
+            fn from_elem(elem_def: &ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
                 Ok(Self::new(elem_def.id.to_owned(), element))
             }
 

--- a/src/webdynpro/element/system/client_inspector.rs
+++ b/src/webdynpro/element/system/client_inspector.rs
@@ -142,7 +142,7 @@ impl<'a> Element<'a> for ClientInspector<'a> {
     }
 
     fn from_elem(
-        elem_def: ElementDef<'a, Self>,
+        elem_def: &ElementDef<'a, Self>,
         element: scraper::ElementRef<'a>,
     ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))

--- a/src/webdynpro/element/system/custom.rs
+++ b/src/webdynpro/element/system/custom.rs
@@ -84,7 +84,7 @@ impl<'a> Element<'a> for Custom {
     }
 
     fn from_elem(
-        elem_def: ElementDef<'_, Self>,
+        elem_def: &ElementDef<'_, Self>,
         _element: scraper::ElementRef,
     ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned()))

--- a/src/webdynpro/element/unknown.rs
+++ b/src/webdynpro/element/unknown.rs
@@ -31,7 +31,7 @@ impl<'a> Element<'a> for Unknown<'a> {
     }
 
     fn from_elem(
-        elem_def: ElementDef<'a, Self>,
+        elem_def: &ElementDef<'a, Self>,
         element: scraper::ElementRef<'a>,
     ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id.to_owned(), element))

--- a/src/webdynpro/mod.rs
+++ b/src/webdynpro/mod.rs
@@ -21,21 +21,34 @@
 //! 엘리먼트의 종류나 렌더링 방법에 따라 엘리먼트 자체를 감싸는 태그가 있을 수 있습니다. 이런 태그는 보통 해당 엘리먼트의 ID 뒤에 `-r` 접미사가 붙는것으로 확인할 수 있습니다.
 //!
 //! ## 애플리케이션 정의 예시
-//! [`USaintApplication`]을 활용하여 [예시](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW2100?sap-wd-stableids=x&sap-language=ko) 애플리케이션 상단의 "담당자문의 정보" 텍스트를 파싱하는 예시 애플리케이션입니다.
+//! [`USaintClient`]를 활용하여 [예시](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW2100?sap-wd-stableids=x&sap-language=ko) 애플리케이션 상단의 "담당자문의 정보" 텍스트를 파싱하는 예시 애플리케이션입니다.
 //!
-//! [`BasicApplication`]을 활용하여 u-saint 외의 다른 사이트에 대한 정의를 만들 수 있으나, [`LoadingPlaceholder`] 로딩이나 [`ClientInspector`] 처리 등 추가적인 처리가 필요할 수 있습니다.
+//! [`WebDynproClient`](crate::webdynpro::client::WebDynproClient)을 활용하여 u-saint 외의 다른 사이트에 대한 정의를 만들 수 있으나, [`LoadingPlaceholder`] 로딩이나 [`ClientInspector`] 처리 등 추가적인 처리가 필요할 수 있습니다.
 //! 추가 정보는 [`LoadingPlaceholder`], [`ClientInspector`] 와 [`Custom`] 엘리먼트를 참고하십시오.
 //! ```ignore
 //! use futures::executor::block_on;
-//! use rusaint::application::USaintApplication;
+//! use rusaint::application::{USaintClient, USaintClientBuilder, USaintApplication};
 //! use rusaint::define_elements;
 //! use rusaint::webdynpro::element::text::Caption;
 //! use rusaint::RusaintError;
 //!
-//! // USaintApplication을 Wrap한 애플리케이션 struct를 새로 정의합니다.
-//! // BasicApplication 등의 기본 애플리케이션 정의를 사용하면 u-saint 가 아닌 다른 사이트에 적용할 수 있으나, 기본 로딩과 같은 추가 작업이 필요할 수 있습니다.
-//! pub struct ExampleApplication(USaintApplication);
+//! // USaintClient을 Wrap한 애플리케이션 struct를 새로 정의합니다.
+//! // WebDynproClient 등의 기본 애플리케이션 정의를 사용하면 u-saint 가 아닌 다른 사이트에 적용할 수 있으나, 기본 로딩과 같은 추가 작업이 필요할 수 있습니다.
+//! pub struct ExampleApplication {
+//!   client: USaintClient
+//! };
 //!
+//! impl USaintApplication for ExampleApplication {
+//!   const APP_NAME: &'static str = "ZCMW2100";
+//!
+//!   fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+//!     if client.name() != Self::APP_NAME {
+//!       Err(RusaintError::InvalidClientError)
+//!     } else {
+//!       Ok(Self { client })
+//!     }
+//!   }
+//! }
 //!
 //! impl<'a> ExampleApplication {
 //!     // 엘리먼트를 정의하는 매크로
@@ -44,25 +57,18 @@
 //!         CAPTION: Caption<'a> = "ZCMW_DEVINFO_RE.ID_D080C16F227F4D68751326DC40BB6BE0:MAIN.CAPTION";
 //!     }
 //!
-//!     // 애플리케이션 생성 함수
-//!     pub async fn new() -> Result<ExampleApplication, RusaintError> {
-//!         // USaintApplication 을 익명 세션으로 생성하고, 이를 Wrap한 ExampleApplication을 생성
-//!         Ok(ExampleApplication(
-//!             USaintApplication::new("ZCMW2100").await?,
-//!         ))
-//!     }
 //!
 //!     // 캡션의 데이터를 읽는 함수
 //!     pub fn read_caption(&self) -> Result<String, RusaintError> {
 //!         // 캡션 정의와 현재 애플리케이션 바디로부터 엘리먼트 객체 생성
-//!         let caption = Self::CAPTION.from_body(self.body())?;
+//!         let caption = Self::CAPTION.from_body(self.client.body())?;
 //!         // 캡션 엘리먼트로부터 텍스트를 반환
 //!         Ok(caption.text().to_string())
 //!     }
 //! }
 //!
 //! async fn test_caption() {
-//!     let app = ExampleApplication::new().await.unwrap();
+//!     let app = USaintClientBuilder::new().build_into<ExampleApplication>().await.unwrap();
 //!     let text = app.read_caption().unwrap();
 //!     assert_eq!(text, "담당자문의 정보");
 //! }

--- a/src/webdynpro/mod.rs
+++ b/src/webdynpro/mod.rs
@@ -83,6 +83,10 @@
 pub mod client;
 /// WebDynpro 페이지를 구성하는 엘리먼트
 pub mod element;
+
+/// WebDynpro 클라이언트를 조작하는 명령
+pub mod command;
+
 /// WebDynpro 클라이언트 작업 중 발생할 수 있는 오류
 pub mod error;
 /// WebDynpro 엘리먼트가 발생시키는 이벤트 처리

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -5,7 +5,7 @@ use dotenv::dotenv;
 use rusaint::{
     application::{
         course_grades::{model::CourseType, CourseGrades},
-        USaintApplicationBuilder,
+        USaintClientBuilder,
     },
     model::SemesterType,
     USaintSession,
@@ -34,7 +34,7 @@ async fn get_session() -> Result<Arc<USaintSession>> {
 #[serial]
 async fn recorded_summary() {
     let session = get_session().await.unwrap();
-    let mut app = USaintApplicationBuilder::new()
+    let mut app = USaintClientBuilder::new()
         .session(session)
         .build_into::<CourseGrades>()
         .await
@@ -52,7 +52,7 @@ async fn recorded_summary() {
 #[serial]
 async fn certificated_summary() {
     let session = get_session().await.unwrap();
-    let mut app = USaintApplicationBuilder::new()
+    let mut app = USaintClientBuilder::new()
         .session(session)
         .build_into::<CourseGrades>()
         .await
@@ -68,7 +68,7 @@ async fn certificated_summary() {
 #[serial]
 async fn semesters() {
     let session = get_session().await.unwrap();
-    let mut app = USaintApplicationBuilder::new()
+    let mut app = USaintClientBuilder::new()
         .session(session)
         .build_into::<CourseGrades>()
         .await
@@ -82,7 +82,7 @@ async fn semesters() {
 #[serial]
 async fn classes_with_detail() {
     let session = get_session().await.unwrap();
-    let mut app = USaintApplicationBuilder::new()
+    let mut app = USaintClientBuilder::new()
         .session(session)
         .build_into::<CourseGrades>()
         .await

--- a/tests/webdynpro/element/button.rs
+++ b/tests/webdynpro/element/button.rs
@@ -1,12 +1,13 @@
 use rusaint::{
+    application::USaintClientBuilder,
     define_elements,
     webdynpro::{
         element::{
             action::{Button, Link},
             text::TextView,
         },
-        error::WebDynproError, application::Application,
-    }, application::USaintApplicationBuilder,
+        error::WebDynproError,
+    },
 };
 
 use crate::get_session;
@@ -25,15 +26,15 @@ impl<'a> EventTestSuite {
         let load_btn_pane = {
             let body = self.body();
             let link = Self::LINK_TO_BUTTON.from_body(body)?;
-            vec![link.activate(false, false)?]
+            link.activate(false, false)?
         };
-        self.send_events(load_btn_pane).await?;
+        self.process_event(false, load_btn_pane).await?;
         let btn_events = {
             let body = self.body();
             let btn = Self::TEST_BUTTON.from_body(body)?;
-            vec![btn.press()?]
+            btn.press()?
         };
-        self.send_events(btn_events).await?;
+        self.process_event(false, btn_events).await?;
         assert_eq!(
             Self::TEST_BUTTON_TEXTVIEW.from_body(self.body())?.text(),
             "An action has been triggered."
@@ -45,6 +46,10 @@ impl<'a> EventTestSuite {
 #[tokio::test]
 async fn test_button_events() {
     let session = get_session().await.unwrap();
-    let mut suite = USaintApplicationBuilder::new().session(session).build_into::<EventTestSuite>().await.unwrap();
+    let mut suite = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<EventTestSuite>()
+        .await
+        .unwrap();
     suite.test_button().await.unwrap();
 }

--- a/tests/webdynpro/element/mod.rs
+++ b/tests/webdynpro/element/mod.rs
@@ -1,5 +1,43 @@
-use rusaint::{application::USaintApplication, define_usaint_application};
+use rusaint::{
+    application::{USaintApplication, USaintClient},
+    webdynpro::{
+        client::{body::Body, EventProcessResult},
+        error::WebDynproError,
+        event::Event,
+    },
+    RusaintError,
+};
 
-define_usaint_application!(pub(crate) struct EventTestSuite<"WDR_TEST_EVENTS">);
+pub(crate) struct EventTestSuite {
+    client: USaintClient,
+}
+
+impl EventTestSuite {
+    pub fn body(&self) -> &Body {
+        self.client.body()
+    }
+
+    pub async fn process_event(
+        &mut self,
+        force_send: bool,
+        event: Event,
+    ) -> Result<EventProcessResult, WebDynproError> {
+        self.client.process_event(force_send, event).await
+    }
+}
+
+impl USaintApplication for EventTestSuite {
+    const APP_NAME: &'static str = "WDR_TEST_EVENTS";
+
+    fn from_client(
+        client: rusaint::application::USaintClient,
+    ) -> Result<Self, rusaint::RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(EventTestSuite { client })
+        }
+    }
+}
 
 mod button;


### PR DESCRIPTION
# What's in this pull request

- `WebDynproCommand` 트레이트 구조체를 이용하여 `WebDynproClient`를 사용할 수 있도록 메소드를 추가했습니다.
- 일부 간단한 작업에 한해서 지원하며, `SapTable` 등의 복잡한 엘리먼트를 다룰 때에는 엘리먼트에 직접 접근하는 기존 방법을 사용하여야 합니다.
- 기존 형태의 `Application`을 제거하고 `WebDynproClient`(기존 `BasicWDApplication`)과 각 애플리케이션이 직접 상속되지 않도록 애플리케이션과 클라이언트를 완전히 분리하였습니다. 따라서 애플리케이션의 형태가 조금 더 유연해지고 구현하기 간단해집니다.

## TODO
- 테이블 내용 등 복잡한 작업을 간단화할 방법 찾기