### PR TITLE
[refactor] `Element`반환 함수가 대신 `ElementDef`를 반환하도록 변경

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -196,7 +196,7 @@ pub async fn obtain_ssu_sso_token(id: &str, password: &str) -> Result<String, Ss
 
 #[cfg(test)]
 mod test {
-    use crate::session::{obtain_ssu_sso_token, USaintSession};
+    use crate::session::USaintSession;
     use dotenv::dotenv;
 
     #[tokio::test]

--- a/src/webdynpro/element/complex/sap_table/body.rs
+++ b/src/webdynpro/element/complex/sap_table/body.rs
@@ -7,7 +7,7 @@ use crate::webdynpro::{element::ElementDef, error::ElementError};
 use super::{property::SapTableRowType, row::SapTableRow, SapTable};
 
 /// [`SapTable`] 내부 테이블
-#[derive(custom_debug_derive::Debug)]
+#[derive(Clone, custom_debug_derive::Debug)]
 #[allow(unused)]
 pub struct SapTableBody<'a> {
     table_def: ElementDef<'a, SapTable<'a>>,

--- a/src/webdynpro/element/complex/sap_table/cell/header_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/header_cell.rs
@@ -7,10 +7,7 @@ use crate::webdynpro::{
         complex::sap_table::property::{
             SapTableHeaderCellDesign, SapTableHeaderCellType, SapTableRowSelectionMassState,
             SapTableSelectionColumnAction,
-        },
-        define_lsdata,
-        property::SortState,
-        Element, ElementWrapper, SubElement, SubElementDef,
+        }, define_lsdata, property::SortState, Element, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef
     },
     error::{BodyError, WebDynproError},
 };
@@ -24,7 +21,7 @@ pub struct SapTableHeaderCell<'a> {
     #[debug(skip)]
     element_ref: scraper::ElementRef<'a>,
     lsdata: OnceCell<SapTableHeaderCellLSData>,
-    content: OnceCell<Option<ElementWrapper<'a>>>,
+    content: OnceCell<Option<ElementDefWrapper<'a>>>,
 }
 
 define_lsdata! {
@@ -84,22 +81,21 @@ impl<'a> SubElement<'a> for SapTableHeaderCell<'a> {
 }
 
 impl<'a> SapTableCell<'a> for SapTableHeaderCell<'a> {
-    fn content(&self) -> Option<&ElementWrapper<'a>> {
+    fn content(&self) -> Option<ElementDefWrapper<'a>> {
         self.content
             .get_or_init(|| {
                 let content_selector =
                     Selector::parse(format!(r#"[id="{}-CONTENT"] [ct]"#, &self.id).as_str())
                         .or(Err(BodyError::InvalidSelector))
                         .ok()?;
-                ElementWrapper::dyn_elem(
+                ElementDefWrapper::dyn_elem_def(
                     self.element_ref
                         .select(&content_selector)
                         .next()?
                         .to_owned(),
                 )
                 .ok()
-            })
-            .as_ref()
+            }).to_owned()
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/header_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/header_cell.rs
@@ -7,7 +7,7 @@ use crate::webdynpro::{
         complex::sap_table::property::{
             SapTableHeaderCellDesign, SapTableHeaderCellType, SapTableRowSelectionMassState,
             SapTableSelectionColumnAction,
-        }, define_lsdata, property::SortState, Element, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef
+        }, define_lsdata, property::SortState, Element, ElementDefWrapper, SubElement, SubElementDef
     },
     error::{BodyError, WebDynproError},
 };

--- a/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
@@ -5,7 +5,7 @@ use scraper::Selector;
 use crate::webdynpro::{
     element::{
         complex::sap_table::property::{SapTableCellDesign, SapTableHierarchicalCellStatus},
-        define_lsdata, Element, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef,
+        define_lsdata, Element, ElementDefWrapper, SubElement, SubElementDef,
     },
     error::WebDynproError,
 };

--- a/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
@@ -5,7 +5,7 @@ use scraper::Selector;
 use crate::webdynpro::{
     element::{
         complex::sap_table::property::{SapTableCellDesign, SapTableHierarchicalCellStatus},
-        define_lsdata, Element, ElementWrapper, SubElement, SubElementDef,
+        define_lsdata, Element, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef,
     },
     error::WebDynproError,
 };
@@ -19,7 +19,7 @@ pub struct SapTableHierarchicalCell<'a> {
     #[debug(skip)]
     element_ref: scraper::ElementRef<'a>,
     lsdata: OnceCell<SapTableHierarchicalCellLSData>,
-    content: OnceCell<Option<ElementWrapper<'a>>>,
+    content: OnceCell<Option<ElementDefWrapper<'a>>>,
 }
 define_lsdata! {
     #[doc = "[`SapTableHierarchicalCell`] 내부 데이터"]
@@ -38,11 +38,11 @@ define_lsdata! {
 }
 
 impl<'a> SapTableCell<'a> for SapTableHierarchicalCell<'a> {
-    fn content(&self) -> Option<&ElementWrapper<'a>> {
+    fn content(&self) -> Option<ElementDefWrapper<'a>> {
         self.content
             .get_or_init(|| {
                 let content_selector = Selector::parse(":root [ct]").unwrap();
-                ElementWrapper::dyn_elem(
+                ElementDefWrapper::dyn_elem_def(
                     self.element_ref
                         .select(&content_selector)
                         .next()?
@@ -50,7 +50,7 @@ impl<'a> SapTableCell<'a> for SapTableHierarchicalCell<'a> {
                 )
                 .ok()
             })
-            .as_ref()
+            .to_owned()
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
@@ -5,7 +5,7 @@ use scraper::Selector;
 use crate::webdynpro::{
     element::{
         complex::sap_table::property::SapTableCellDesign, define_lsdata, Element,
-        ElementDefWrapper, ElementWrapper, SubElement, SubElementDef,
+        ElementDefWrapper, SubElement, SubElementDef,
     },
     error::WebDynproError,
 };

--- a/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
@@ -4,8 +4,8 @@ use scraper::Selector;
 
 use crate::webdynpro::{
     element::{
-        complex::sap_table::property::SapTableCellDesign, define_lsdata, Element, ElementWrapper,
-        SubElement, SubElementDef,
+        complex::sap_table::property::SapTableCellDesign, define_lsdata, Element,
+        ElementDefWrapper, ElementWrapper, SubElement, SubElementDef,
     },
     error::WebDynproError,
 };
@@ -19,7 +19,7 @@ pub struct SapTableMatrixCell<'a> {
     #[debug(skip)]
     element_ref: scraper::ElementRef<'a>,
     lsdata: OnceCell<SapTableMatrixCellLSData>,
-    content: OnceCell<Option<ElementWrapper<'a>>>,
+    content: OnceCell<Option<ElementDefWrapper<'a>>>,
 }
 
 define_lsdata! {
@@ -33,11 +33,11 @@ define_lsdata! {
 }
 
 impl<'a> SapTableCell<'a> for SapTableMatrixCell<'a> {
-    fn content(&self) -> Option<&ElementWrapper<'a>> {
+    fn content(&self) -> Option<ElementDefWrapper<'a>> {
         self.content
             .get_or_init(|| {
                 let content_selector = Selector::parse(":root [ct]").unwrap();
-                ElementWrapper::dyn_elem(
+                ElementDefWrapper::dyn_elem_def(
                     self.element_ref
                         .select(&content_selector)
                         .next()?
@@ -45,7 +45,7 @@ impl<'a> SapTableCell<'a> for SapTableMatrixCell<'a> {
                 )
                 .ok()
             })
-            .as_ref()
+            .to_owned()
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/mod.rs
@@ -1,5 +1,5 @@
 use crate::webdynpro::client::body::Body;
-use crate::webdynpro::element::{ElementDef, ElementWrapper, SubElement, SubElementDef};
+use crate::webdynpro::element::{ElementDef, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef};
 use crate::webdynpro::error::WebDynproError;
 
 /// [`SapTable`] 셀의 Wrapper
@@ -174,11 +174,11 @@ impl<'a> SapTableCellDefWrapper<'a> {
 /// [`SapTable`]의 공통된 셀 기능
 pub trait SapTableCell<'a> {
     /// 셀 내부 컨텐츠 엘리먼트를 반환합니다.
-    fn content(&self) -> Option<&ElementWrapper<'a>>;
+    fn content(&self) -> Option<ElementDefWrapper<'a>>;
 }
 
 impl<'a> SapTableCell<'a> for SapTableCellWrapper<'a> {
-    fn content(&self) -> Option<&ElementWrapper<'a>> {
+    fn content(&self) -> Option<ElementDefWrapper<'a>> {
         match self {
             SapTableCellWrapper::Normal(elem) => elem.content(),
             SapTableCellWrapper::Header(elem) => elem.content(),

--- a/src/webdynpro/element/complex/sap_table/cell/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/mod.rs
@@ -1,5 +1,5 @@
 use crate::webdynpro::client::body::Body;
-use crate::webdynpro::element::{ElementDef, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef};
+use crate::webdynpro::element::{ElementDef, ElementDefWrapper, SubElement, SubElementDef};
 use crate::webdynpro::error::WebDynproError;
 
 /// [`SapTable`] 셀의 Wrapper

--- a/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
@@ -4,7 +4,7 @@ use scraper::Selector;
 
 use crate::webdynpro::{
     element::{
-        complex::sap_table::property::{SapTableCellDesign, SapTableCellType}, define_lsdata, Element, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef
+        complex::sap_table::property::{SapTableCellDesign, SapTableCellType}, define_lsdata, Element, ElementDefWrapper, SubElement, SubElementDef
     },
     error::WebDynproError,
 };

--- a/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
@@ -4,8 +4,7 @@ use scraper::Selector;
 
 use crate::webdynpro::{
     element::{
-        complex::sap_table::property::{SapTableCellDesign, SapTableCellType},
-        define_lsdata, Element, ElementWrapper, SubElement, SubElementDef,
+        complex::sap_table::property::{SapTableCellDesign, SapTableCellType}, define_lsdata, Element, ElementDefWrapper, ElementWrapper, SubElement, SubElementDef
     },
     error::WebDynproError,
 };
@@ -19,7 +18,7 @@ pub struct SapTableNormalCell<'a> {
     #[debug(skip)]
     element_ref: scraper::ElementRef<'a>,
     lsdata: OnceCell<SapTableNormalCellLSData>,
-    content: OnceCell<Option<ElementWrapper<'a>>>,
+    content: OnceCell<Option<ElementDefWrapper<'a>>>,
 }
 
 define_lsdata! {
@@ -37,19 +36,18 @@ define_lsdata! {
 }
 
 impl<'a> SapTableCell<'a> for SapTableNormalCell<'a> {
-    fn content(&self) -> Option<&ElementWrapper<'a>> {
+    fn content(&self) -> Option<ElementDefWrapper<'a>> {
         self.content
             .get_or_init(|| {
                 let content_selector = Selector::parse(":root [ct]").unwrap();
-                ElementWrapper::dyn_elem(
+                ElementDefWrapper::dyn_elem_def(
                     self.element_ref
                         .select(&content_selector)
                         .next()?
                         .to_owned(),
                 )
                 .ok()
-            })
-            .as_ref()
+            }).to_owned()
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
@@ -4,8 +4,8 @@ use scraper::Selector;
 
 use crate::webdynpro::{
     element::{
-        complex::sap_table::property::SapTableCellType, define_lsdata, Element, ElementWrapper,
-        SubElement, SubElementDef,
+        complex::sap_table::property::SapTableCellType, define_lsdata, Element, ElementDefWrapper,
+        ElementWrapper, SubElement, SubElementDef,
     },
     error::WebDynproError,
 };
@@ -19,7 +19,7 @@ pub struct SapTableSelectionCell<'a> {
     #[debug(skip)]
     element_ref: scraper::ElementRef<'a>,
     lsdata: OnceCell<SapTableSelectionCellLSData>,
-    content: OnceCell<Option<ElementWrapper<'a>>>,
+    content: OnceCell<Option<ElementDefWrapper<'a>>>,
 }
 
 define_lsdata! {
@@ -37,11 +37,11 @@ define_lsdata! {
 }
 
 impl<'a> SapTableCell<'a> for SapTableSelectionCell<'a> {
-    fn content(&self) -> Option<&ElementWrapper<'a>> {
+    fn content(&self) -> Option<ElementDefWrapper<'a>> {
         self.content
             .get_or_init(|| {
                 let content_selector = Selector::parse(":root > div > div [ct]").unwrap();
-                ElementWrapper::dyn_elem(
+                ElementDefWrapper::dyn_elem_def(
                     self.element_ref
                         .select(&content_selector)
                         .next()?
@@ -49,7 +49,7 @@ impl<'a> SapTableCell<'a> for SapTableSelectionCell<'a> {
                 )
                 .ok()
             })
-            .as_ref()
+            .to_owned()
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
@@ -4,8 +4,7 @@ use scraper::Selector;
 
 use crate::webdynpro::{
     element::{
-        complex::sap_table::property::SapTableCellType, define_lsdata, Element, ElementDefWrapper,
-        ElementWrapper, SubElement, SubElementDef,
+        complex::sap_table::property::SapTableCellType, define_lsdata, Element, ElementDefWrapper, SubElement, SubElementDef,
     },
     error::WebDynproError,
 };

--- a/src/webdynpro/element/definition/mod.rs
+++ b/src/webdynpro/element/definition/mod.rs
@@ -85,6 +85,17 @@ where
         }
     }
 
+    pub(crate) fn from_element_ref(
+        element: scraper::ElementRef<'a>,
+    ) -> Result<ElementDef<'a, T>, WebDynproError> {
+        let id = element.value().id().ok_or(BodyError::InvalidElement)?;
+        Ok(ElementDef {
+            id: id.to_string().into(),
+            node_id: None,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
     /// 빠른 엘리먼트 탐색을 위해 `ego_tree::NodeId`와 함께 엘리먼트 정의를 생성합니다.
     pub fn with_node_id(
         id: String,

--- a/src/webdynpro/element/definition/sub.rs
+++ b/src/webdynpro/element/definition/sub.rs
@@ -5,7 +5,7 @@ use scraper::Selector;
 use crate::webdynpro::{
     client::body::Body,
     element::{Element, SubElement},
-    error::{ElementError, WebDynproError},
+    error::{BodyError, ElementError, WebDynproError},
 };
 
 use super::{ElementDef, ElementNodeId};
@@ -79,6 +79,19 @@ where
             node_id: Some(ElementNodeId { body_hash, node_id }),
             _marker: std::marker::PhantomData,
         }
+    }
+
+    pub(crate) fn from_element_ref(
+        parent: ElementDef<'a, Parent>,
+        element: scraper::ElementRef<'a>,
+    ) -> Result<SubElementDef<'a, Parent, T>, WebDynproError> {
+        let id = element.value().id().ok_or(BodyError::InvalidElement)?;
+        Ok(SubElementDef {
+            id: id.to_string().into(),
+            parent,
+            node_id: None,
+            _marker: std::marker::PhantomData,
+        })
     }
 
     /// 서브 엘리먼트의 Id를 반환합니다.

--- a/src/webdynpro/element/layout/button_row.rs
+++ b/src/webdynpro/element/layout/button_row.rs
@@ -2,13 +2,13 @@ use scraper::Selector;
 use std::{borrow::Cow, cell::OnceCell};
 
 use crate::webdynpro::element::{
-    action::Button, define_element_base, property::Visibility, ElementWrapper,
+    action::Button, define_element_base, definition::ElementDef, property::Visibility
 };
 
 define_element_base! {
     #[doc = "[`Button`]의 나열"]
     ButtonRow<"BR", "ButtonRow"> {
-        buttons: OnceCell<Vec<Button<'a>>>
+        buttons: OnceCell<Vec<ElementDef<'a, Button<'a>>>>
     },
     #[doc = "[`ButtonRow`] 내부 데이터"]
     ButtonRowLSData {
@@ -29,20 +29,20 @@ impl<'a> ButtonRow<'a> {
     }
 
     /// 내부 [`Button`]을 반환합니다.
-    pub fn buttons(&'a self) -> impl Iterator<Item = &Button<'a>> + ExactSizeIterator {
+    pub fn buttons(&'a self) -> impl Iterator<Item = &ElementDef<'a, Button<'a>>> + ExactSizeIterator {
         self.buttons
             .get_or_init(|| {
                 let button_selector = &Selector::parse(r#":root [ct="B"]"#).unwrap();
                 self.element_ref
                     .select(button_selector)
                     .filter_map(|elem| {
-                        let elem = ElementWrapper::dyn_elem(elem);
-                        match elem {
-                            Ok(ElementWrapper::Button(button)) => Some(button),
-                            _ => None,
+                        let def = ElementDef::from_element_ref(elem);
+                        match def {
+                            Ok(button_def) => Some(button_def),
+                            _ => None
                         }
                     })
-                    .collect::<Vec<Button<'a>>>()
+                    .collect::<Vec<ElementDef<'a, Button<'a>>>>()
             })
             .iter()
     }

--- a/src/webdynpro/element/mod.rs
+++ b/src/webdynpro/element/mod.rs
@@ -241,6 +241,7 @@ macro_rules! register_elements {
 
         /// 다양한 [`Element`]를 대상으로 하는 [`ElementDef`]를 공통의 타입으로 취급할 수 있게 하는 Wrapper
         #[allow(missing_docs)]
+        #[derive(Clone, Debug)]
         pub enum ElementDefWrapper<'a> {
             $( $enum($crate::webdynpro::element::definition::ElementDef::<'a, $type>), )*
             Unknown($crate::webdynpro::element::definition::ElementDef::<'a, $crate::webdynpro::element::unknown::Unknown<'a>>)

--- a/src/webdynpro/element/mod.rs
+++ b/src/webdynpro/element/mod.rs
@@ -238,6 +238,26 @@ macro_rules! register_elements {
                 }
             }
         )+
+
+        /// 다양한 [`Element`]를 대상으로 하는 [`ElementDef`]를 공통의 타입으로 취급할 수 있게 하는 Wrapper
+        #[allow(missing_docs)]
+        pub enum ElementDefWrapper<'a> {
+            $( $enum($crate::webdynpro::element::definition::ElementDef::<'a, $type>), )*
+            Unknown($crate::webdynpro::element::definition::ElementDef::<'a, $crate::webdynpro::element::unknown::Unknown<'a>>)
+        }
+
+        impl<'a> ElementDefWrapper<'a> {
+        	/// 분류를 알 수 없는 엘리먼트의 `scraper::ElementRef`로 [`ElementDefWrapper`]를 반환합니다.
+            pub fn dyn_elem_def(element: scraper::ElementRef<'a>) -> Result<ElementDefWrapper<'a>, WebDynproError> {
+                let value = element.value();
+                let id = value.id().ok_or(BodyError::NoSuchAttribute("id".to_owned()))?.to_owned();
+                #[allow(unreachable_patterns)]
+                match element.value().attr("ct") {
+                    $( Some(<$type>::CONTROL_ID) => Ok(ElementDefWrapper::$enum($crate::webdynpro::element::definition::ElementDef::<$type>::new_dynamic(id))), )*
+                    _ => Ok(ElementDefWrapper::Unknown($crate::webdynpro::element::definition::ElementDef::<$crate::webdynpro::element::unknown::Unknown>::new_dynamic(id)))
+                }
+            }
+        }
         
     };
 }


### PR DESCRIPTION
# What's in this pull request

- `impl Element`, `ElementWrapper`, `impl SubElement` 를 반환하는 함수들을  `ElementDef`, `ElementDefWrapper`, `SubElementDef`를 반환하도록 변경
- 추후 최적화 변경을 위해 `from_element_ref` 함수 추가