### PR TITLE
[refactor] `ElementDef` 와 `SubElementDef`를 `ElementDefinition` 과 `SubElementDefinition` 트레이트를 구현하는 각자의 구조체로 변경

### DIFF
--- a/src/application/course_schedule.rs
+++ b/src/application/course_schedule.rs
@@ -3,7 +3,7 @@ use crate::{
     model::SemesterType,
     webdynpro::{
         client::body::Body,
-        element::{action::Button, complex::SapTable, layout::TabStrip, selection::ComboBox},
+        element::{action::Button, complex::SapTable, definition::ElementDefinition, layout::TabStrip, selection::ComboBox},
         error::WebDynproError,
     },
     RusaintError,
@@ -118,9 +118,7 @@ mod test {
     use crate::{
         application::{course_schedule::CourseSchedule, USaintClientBuilder},
         webdynpro::element::{
-            complex::sap_table::cell::{SapTableCell, SapTableCellWrapper},
-            selection::list_box::{item::ListBoxItemWrapper, ListBoxWrapper},
-            ElementWrapper,
+            complex::sap_table::cell::{SapTableCell, SapTableCellWrapper}, definition::ElementDefinition, selection::list_box::{item::ListBoxItemWrapper, ListBoxWrapper}, ElementWrapper
         },
     };
 
@@ -132,7 +130,7 @@ mod test {
             .unwrap();
         let ct_selector = scraper::Selector::parse("[ct]").unwrap();
         for elem_ref in app.body().document().select(&ct_selector) {
-            let elem = ElementWrapper::dyn_elem(elem_ref);
+            let elem = ElementWrapper::dyn_element(elem_ref);
             if let Ok(elem) = elem {
                 println!("{:?}", elem);
             }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         command::WebDynproCommand,
         element::{
             define_elements,
+            definition::ElementDefinition,
             system::{ClientInspector, Custom, CustomClientInfo, LoadingPlaceholder},
         },
         error::WebDynproError,

--- a/src/application/student_information.rs
+++ b/src/application/student_information.rs
@@ -64,7 +64,7 @@ mod test {
             .unwrap();
         let ct_selector = scraper::Selector::parse("[ct]").unwrap();
         for elem_ref in app.body().document().select(&ct_selector) {
-            let elem = ElementWrapper::dyn_elem(elem_ref);
+            let elem = ElementWrapper::dyn_element(elem_ref);
             if let Ok(elem) = elem {
                 println!("{:?}", elem);
             }

--- a/src/webdynpro/client/body/mod.rs
+++ b/src/webdynpro/client/body/mod.rs
@@ -15,6 +15,7 @@ type BodyUpdateControlId = String;
 
 #[derive(Debug)]
 pub(super) enum BodyUpdateType {
+    #[allow(dead_code)]
     Full(BodyUpdateWindowId, BodyUpdateContentId, String),
     Delta(BodyUpdateWindowId, HashMap<BodyUpdateControlId, String>),
 }

--- a/src/webdynpro/client/mod.rs
+++ b/src/webdynpro/client/mod.rs
@@ -12,7 +12,7 @@ use reqwest::{cookie::Jar, header::*, RequestBuilder};
 use std::sync::Arc;
 use url::Url;
 
-use super::command::WebDynproCommand;
+use super::{command::WebDynproCommand, element::definition::ElementDefinition};
 
 /// WebDynpro 애플리케이션의 웹 요청 및 페이지 문서 처리를 담당하는 클라이언트
 pub struct WebDynproClient {

--- a/src/webdynpro/command/element/action.rs
+++ b/src/webdynpro/command/element/action.rs
@@ -1,21 +1,23 @@
 use crate::webdynpro::{
-    client::EventProcessResult, command::WebDynproCommand, element::{action::Button, definition::ElementDef},
+    client::EventProcessResult,
+    command::WebDynproCommand,
+    element::{action::ButtonDef, definition::ElementDefinition},
     error::WebDynproError,
 };
 
 /// 주어진 [`Button`]을 누름
-pub struct ButtonPressCommand<'a> {
-    element_def: ElementDef<'a, Button<'a>>,
+pub struct ButtonPressCommand {
+    element_def: ButtonDef,
 }
 
-impl<'a> ButtonPressCommand<'a> {
+impl ButtonPressCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: ElementDef<'a, Button<'a>>) -> ButtonPressCommand<'a> {
+    pub fn new(element_def: ButtonDef) -> ButtonPressCommand {
         ButtonPressCommand { element_def }
     }
 }
 
-impl<'a> WebDynproCommand for ButtonPressCommand<'a> {
+impl WebDynproCommand for ButtonPressCommand {
     type Result = EventProcessResult;
 
     async fn dispatch(

--- a/src/webdynpro/command/element/selection.rs
+++ b/src/webdynpro/command/element/selection.rs
@@ -2,31 +2,32 @@ use crate::webdynpro::{
     client::EventProcessResult,
     command::WebDynproCommand,
     element::{
-        selection::{ComboBox, ComboBoxLSData},
-        Element, definition::ElementDef,
+        definition::ElementDefinition,
+        selection::{ComboBoxDef, ComboBoxLSData},
+        Element,
     },
     error::WebDynproError,
 };
 
 /// [`ComboBox`]의 선택지를 선택하도록 함
-pub struct ComboBoxSelectCommand<'a> {
-    element_def: ElementDef<'a, ComboBox<'a>>,
+pub struct ComboBoxSelectCommand {
+    element_def: ComboBoxDef,
     key: String,
     by_enter: bool,
 }
 
-impl<'a> ComboBoxSelectCommand<'a> {
-  /// 새로운 명령 객체를 생성합니다.
-  pub fn new(element_def: ElementDef<'a, ComboBox<'a>>, key: &str, by_enter: bool) -> ComboBoxSelectCommand<'a> {
-    Self {
-      element_def,
-      key: key.to_string(),
-      by_enter
+impl ComboBoxSelectCommand {
+    /// 새로운 명령 객체를 생성합니다.
+    pub fn new(element_def: ComboBoxDef, key: &str, by_enter: bool) -> ComboBoxSelectCommand {
+        Self {
+            element_def,
+            key: key.to_string(),
+            by_enter,
+        }
     }
-  }
 }
 
-impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
+impl WebDynproCommand for ComboBoxSelectCommand {
     type Result = EventProcessResult;
 
     async fn dispatch(
@@ -42,18 +43,18 @@ impl<'a> WebDynproCommand for ComboBoxSelectCommand<'a> {
 }
 
 /// [`ComboBoxLSData`]를 반환
-pub struct ReadComboBoxLSDataCommand<'a> {
-    element_def: ElementDef<'a, ComboBox<'a>>,
+pub struct ReadComboBoxLSDataCommand {
+    element_def: ComboBoxDef,
 }
 
-impl<'a> ReadComboBoxLSDataCommand<'a> {
-  /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: ElementDef<'a, ComboBox<'a>>) -> ReadComboBoxLSDataCommand<'a> {
+impl ReadComboBoxLSDataCommand {
+    /// 새로운 명령 객체를 생성합니다.
+    pub fn new(element_def: ComboBoxDef) -> ReadComboBoxLSDataCommand {
         Self { element_def }
     }
 }
 
-impl<'a> WebDynproCommand for ReadComboBoxLSDataCommand<'a> {
+impl WebDynproCommand for ReadComboBoxLSDataCommand {
     type Result = ComboBoxLSData;
 
     async fn dispatch(

--- a/src/webdynpro/element/action/button.rs
+++ b/src/webdynpro/element/action/button.rs
@@ -69,6 +69,8 @@ pub mod property {
 define_element_interactable! {
     #[doc = "누를 수 있는 버튼"]
     Button<"B", "Button"> {},
+    #[doc = "[`Button`]의 정의"]
+    ButtonDef,
     #[doc = "[`Button`]의 내부 데이터"]
     ButtonLSData {
         text: String => "0",

--- a/src/webdynpro/element/action/link.rs
+++ b/src/webdynpro/element/action/link.rs
@@ -13,6 +13,8 @@ use crate::webdynpro::{
 define_element_interactable! {
     #[doc = "액션을 수행하거나 링크로 이동하는 하이퍼링크"]
     Link<"LN", "Link"> {},
+    #[doc = "[`Link`]의 정의"]
+    LinkDef,
     #[doc ="[`Link`] 내부 데이터"]
     LinkLSData {
         tooltip: String => "0",

--- a/src/webdynpro/element/action/mod.rs
+++ b/src/webdynpro/element/action/mod.rs
@@ -3,6 +3,6 @@ mod link;
 
 pub use self::button::{
     property::{ButtonDesign, ButtonInteractionBehaviour, ButtonType},
-    Button, ButtonLSData,
+    Button, ButtonDef, ButtonLSData,
 };
-pub use self::link::{Link, LinkLSData};
+pub use self::link::{Link, LinkDef, LinkLSData};

--- a/src/webdynpro/element/complex/mod.rs
+++ b/src/webdynpro/element/complex/mod.rs
@@ -2,4 +2,4 @@
 pub mod sap_table;
 
 #[doc(inline)]
-pub use self::sap_table::{SapTable, SapTableLSData};
+pub use self::sap_table::{SapTable, SapTableDef, SapTableLSData};

--- a/src/webdynpro/element/complex/sap_table/body.rs
+++ b/src/webdynpro/element/complex/sap_table/body.rs
@@ -2,15 +2,15 @@ use std::{iter, ops::Index};
 
 use scraper::ElementRef;
 
-use crate::webdynpro::{element::ElementDef, error::ElementError};
+use crate::webdynpro::{element::definition::ElementDefinition, error::ElementError};
 
-use super::{property::SapTableRowType, row::SapTableRow, SapTable};
+use super::{property::SapTableRowType, row::SapTableRow, SapTableDef};
 
 /// [`SapTable`] 내부 테이블
 #[derive(Clone, custom_debug_derive::Debug)]
 #[allow(unused)]
 pub struct SapTableBody<'a> {
-    table_def: ElementDef<'a, SapTable<'a>>,
+    table_def: SapTableDef,
     #[debug(skip)]
     elem_ref: ElementRef<'a>,
     header: SapTableRow<'a>,
@@ -19,7 +19,7 @@ pub struct SapTableBody<'a> {
 
 impl<'a> SapTableBody<'a> {
     pub(super) fn new(
-        table_def: ElementDef<'a, SapTable<'a>>,
+        table_def: SapTableDef,
         elem_ref: ElementRef<'a>,
     ) -> Result<SapTableBody<'a>, ElementError> {
         let rows_iter = elem_ref
@@ -30,7 +30,10 @@ impl<'a> SapTableBody<'a> {
             .clone()
             .filter(|row| matches!(row.row_type(), SapTableRowType::Header));
         let Some(header) = header_iter.next() else {
-            return Err(ElementError::NoSuchContent { element: table_def.id().to_owned(), content: "Header of table".to_owned() });
+            return Err(ElementError::NoSuchContent {
+                element: table_def.id().to_owned(),
+                content: "Header of table".to_owned(),
+            });
         };
         if header_iter.next().is_some() {
             return Err(ElementError::InvalidContent {
@@ -69,8 +72,8 @@ impl<'a> SapTableBody<'a> {
         iter::once(self.header()).chain(self.rows.iter())
     }
 
-    /// 이 테이블의 원본 [`ElementDef`]를 반환합니다.
-    pub fn table_def(&self) -> ElementDef<'a, SapTable<'a>> {
+    /// 이 테이블의 원본 [`SapTableDef`]를 반환합니다.
+    pub fn table_def(&self) -> SapTableDef {
         self.table_def.clone()
     }
 

--- a/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/hierarchical_cell.rs
@@ -2,26 +2,27 @@ use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 
-use crate::webdynpro::{
-    element::{
-        complex::sap_table::property::{SapTableCellDesign, SapTableHierarchicalCellStatus},
-        define_lsdata, Element, ElementDefWrapper, SubElement, SubElementDef,
+use crate::webdynpro::element::{
+    complex::{
+        sap_table::{
+            property::{SapTableCellDesign, SapTableHierarchicalCellStatus},
+            SapTableDef,
+        },
+        SapTable,
     },
-    error::WebDynproError,
+    sub::define_subelement,
+    ElementDefWrapper,
 };
 
 use super::{SapTableCell, SapTableCellWrapper};
 
-/// 계층적 테이블의 셀
-#[derive(custom_debug_derive::Debug)]
-pub struct SapTableHierarchicalCell<'a> {
-    id: Cow<'static, str>,
-    #[debug(skip)]
-    element_ref: scraper::ElementRef<'a>,
-    lsdata: OnceCell<SapTableHierarchicalCellLSData>,
-    content: OnceCell<Option<ElementDefWrapper<'a>>>,
-}
-define_lsdata! {
+define_subelement! {
+    #[doc = "계층적 [`SapTable`]의 셀"]
+    SapTableHierarchicalCell<SapTable, SapTableDef, "HIC", "SapTableHierarchicalCell"> {
+        content: OnceCell<Option<ElementDefWrapper<'a>>>
+    },
+    #[doc = "[`SapTableHierarchicalCell`]의 정의"]
+    SapTableHierarchicalCellDef,
     #[doc = "[`SapTableHierarchicalCell`] 내부 데이터"]
     SapTableHierarchicalCellLSData {
         is_selected: bool => "0",
@@ -51,38 +52,6 @@ impl<'a> SapTableCell<'a> for SapTableHierarchicalCell<'a> {
                 .ok()
             })
             .to_owned()
-    }
-}
-
-impl<'a> SubElement<'a> for SapTableHierarchicalCell<'a> {
-    const SUBCONTROL_ID: &'static str = "HIC";
-    const ELEMENT_NAME: &'static str = "SapTableHierarchicalCell";
-
-    type SubElementLSData = SapTableHierarchicalCellLSData;
-
-    fn lsdata(&self) -> &Self::SubElementLSData {
-        self.lsdata.get_or_init(|| {
-            let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
-                return Self::SubElementLSData::default();
-            };
-            serde_json::from_value::<Self::SubElementLSData>(lsdata_obj)
-                .unwrap_or(Self::SubElementLSData::default())
-        })
-    }
-
-    fn from_elem<Parent: Element<'a>>(
-        elem_def: SubElementDef<'a, Parent, Self>,
-        element: scraper::ElementRef<'a>,
-    ) -> Result<Self, WebDynproError> {
-        Ok(Self::new(elem_def.id_cow(), element))
-    }
-
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn element_ref(&self) -> &scraper::ElementRef<'a> {
-        &self.element_ref
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/matrix_cell.rs
@@ -2,27 +2,24 @@ use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 
-use crate::webdynpro::{
-    element::{
-        complex::sap_table::property::SapTableCellDesign, define_lsdata, Element,
-        ElementDefWrapper, SubElement, SubElementDef,
+use crate::webdynpro::element::{
+    complex::{
+        sap_table::{property::SapTableCellDesign, SapTableDef},
+        SapTable,
     },
-    error::WebDynproError,
+    sub::define_subelement,
+    ElementDefWrapper,
 };
 
 use super::{SapTableCell, SapTableCellWrapper};
 
-/// 매트릭스 테이블의 셀
-#[derive(custom_debug_derive::Debug)]
-pub struct SapTableMatrixCell<'a> {
-    id: Cow<'static, str>,
-    #[debug(skip)]
-    element_ref: scraper::ElementRef<'a>,
-    lsdata: OnceCell<SapTableMatrixCellLSData>,
-    content: OnceCell<Option<ElementDefWrapper<'a>>>,
-}
-
-define_lsdata! {
+define_subelement! {
+    #[doc = "매트릭스 형태의 [`SapTable`] 셀"]
+    SapTableMatrixCell<SapTable, SapTableDef, "MC", "SapTableMatrixCell"> {
+        content: OnceCell<Option<ElementDefWrapper<'a>>>,
+    },
+    #[doc = "[`SapTableMatrixCell`]의 정의"]
+    SapTableMatrixCellDef,
     #[doc = "[`SapTableMatrixCell`] 내부 데이터"]
     SapTableMatrixCellLSData {
         cell_background_design: SapTableCellDesign => "0",
@@ -46,38 +43,6 @@ impl<'a> SapTableCell<'a> for SapTableMatrixCell<'a> {
                 .ok()
             })
             .to_owned()
-    }
-}
-
-impl<'a> SubElement<'a> for SapTableMatrixCell<'a> {
-    const SUBCONTROL_ID: &'static str = "MC";
-    const ELEMENT_NAME: &'static str = "SapTableMatrixCell";
-
-    type SubElementLSData = SapTableMatrixCellLSData;
-
-    fn lsdata(&self) -> &Self::SubElementLSData {
-        self.lsdata.get_or_init(|| {
-            let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
-                return Self::SubElementLSData::default();
-            };
-            serde_json::from_value::<Self::SubElementLSData>(lsdata_obj)
-                .unwrap_or(Self::SubElementLSData::default())
-        })
-    }
-
-    fn from_elem<Parent: Element<'a>>(
-        elem_def: SubElementDef<'a, Parent, Self>,
-        element: scraper::ElementRef<'a>,
-    ) -> Result<Self, WebDynproError> {
-        Ok(Self::new(elem_def.id_cow(), element))
-    }
-
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn element_ref(&self) -> &scraper::ElementRef<'a> {
-        &self.element_ref
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/mod.rs
@@ -1,5 +1,7 @@
 use crate::webdynpro::client::body::Body;
-use crate::webdynpro::element::{ElementDef, ElementDefWrapper, SubElement, SubElementDef};
+use crate::webdynpro::element::definition::sub::SubElementDefinition;
+use crate::webdynpro::element::sub::SubElement;
+use crate::webdynpro::element::{Element, ElementDefWrapper};
 use crate::webdynpro::error::WebDynproError;
 
 /// [`SapTable`] 셀의 Wrapper
@@ -20,53 +22,53 @@ pub enum SapTableCellWrapper<'a> {
 impl<'a> SapTableCellWrapper<'a> {
     /// 셀을 표현하는 HTML 엘리먼트로부터 [`SapTableCellWrapper`]를 생성합니다.
     pub fn dyn_cell(
-        table_def: ElementDef<'a, SapTable<'a>>,
+        table_def: <SapTable<'a> as Element<'a>>::Def,
         elem_ref: scraper::ElementRef<'a>,
     ) -> Option<SapTableCellWrapper<'a>> {
         let subct_value = elem_ref.value();
         match subct_value.attr("subct") {
             Some(SapTableNormalCell::SUBCONTROL_ID) => Some(
-                SubElementDef::<_, SapTableNormalCell>::new_dynamic(
+                <SapTableNormalCell<'_> as SubElement>::Def::new_dynamic(
                     table_def,
                     subct_value.id()?.to_owned(),
                 )
-                .from_elem(elem_ref)
+                .from_element(elem_ref)
                 .ok()?
                 .wrap(),
             ),
             Some(SapTableHeaderCell::SUBCONTROL_ID) => Some(
-                SubElementDef::<_, SapTableHeaderCell>::new_dynamic(
+                <SapTableHeaderCell<'_> as SubElement>::Def::new_dynamic(
                     table_def,
                     subct_value.id()?.to_owned(),
                 )
-                .from_elem(elem_ref)
+                .from_element(elem_ref)
                 .ok()?
                 .wrap(),
             ),
             Some(SapTableHierarchicalCell::SUBCONTROL_ID) => Some(
-                SubElementDef::<_, SapTableHierarchicalCell>::new_dynamic(
+                <SapTableHierarchicalCell<'_> as SubElement>::Def::new_dynamic(
                     table_def,
                     subct_value.id()?.to_owned(),
                 )
-                .from_elem(elem_ref)
+                .from_element(elem_ref)
                 .ok()?
                 .wrap(),
             ),
             Some(SapTableMatrixCell::SUBCONTROL_ID) => Some(
-                SubElementDef::<_, SapTableMatrixCell>::new_dynamic(
+                <SapTableMatrixCell<'_> as SubElement>::Def::new_dynamic(
                     table_def,
                     subct_value.id()?.to_owned(),
                 )
-                .from_elem(elem_ref)
+                .from_element(elem_ref)
                 .ok()?
                 .wrap(),
             ),
             Some(SapTableSelectionCell::SUBCONTROL_ID) => Some(
-                SubElementDef::<_, SapTableSelectionCell>::new_dynamic(
+                <SapTableSelectionCell<'_> as SubElement>::Def::new_dynamic(
                     table_def,
                     subct_value.id()?.to_owned(),
                 )
-                .from_elem(elem_ref)
+                .from_element(elem_ref)
                 .ok()?
                 .wrap(),
             ),
@@ -77,96 +79,72 @@ impl<'a> SapTableCellWrapper<'a> {
 
 /// [`SapTable`] 셀에 대한 [`SubElementDef`] Wrapper
 #[derive(Clone, Debug)]
-pub enum SapTableCellDefWrapper<'a> {
+pub enum SapTableCellDefWrapper {
     /// 일반 셀 정의
-    Normal(SubElementDef<'a, SapTable<'a>, SapTableNormalCell<'a>>),
+    Normal(SapTableNormalCellDef),
     /// 헤더 셀 정의
-    Header(SubElementDef<'a, SapTable<'a>, SapTableHeaderCell<'a>>),
+    Header(SapTableHeaderCellDef),
     /// 순차형 셀 정의
-    Hierarchical(SubElementDef<'a, SapTable<'a>, SapTableHierarchicalCell<'a>>),
+    Hierarchical(SapTableHierarchicalCellDef),
     /// Matrix 레이아웃용 셀 정의
-    Matrix(SubElementDef<'a, SapTable<'a>, SapTableMatrixCell<'a>>),
+    Matrix(SapTableMatrixCellDef),
     /// 선택을 위한 셀 정의
-    Selection(SubElementDef<'a, SapTable<'a>, SapTableSelectionCell<'a>>),
+    Selection(SapTableSelectionCellDef),
 }
 
-impl<'a> SapTableCellDefWrapper<'a> {
+impl SapTableCellDefWrapper {
     // TODO: include node id in def to improve performance
     /// 셀을 표현하는 HTML 엘리먼트로부터 [`SapTableCellDefWrapper`]를 생성합니다.
     pub fn dyn_cell_def(
-        table_def: ElementDef<'a, SapTable<'a>>,
-        elem_ref: scraper::ElementRef<'a>,
-    ) -> Option<SapTableCellDefWrapper<'a>> {
+        table_def: SapTableDef,
+        elem_ref: scraper::ElementRef<'_>,
+    ) -> Option<SapTableCellDefWrapper> {
         let subct_value = elem_ref.value();
         match subct_value.attr("subct") {
-            Some(SapTableNormalCell::SUBCONTROL_ID) => {
-                Some(SapTableCellDefWrapper::Normal(SubElementDef::<
-                    _,
-                    SapTableNormalCell,
-                >::new_dynamic(
+            Some(SapTableNormalCell::SUBCONTROL_ID) => Some(SapTableCellDefWrapper::Normal(
+                SapTableNormalCellDef::new_dynamic(table_def, subct_value.id()?.to_owned()),
+            )),
+            Some(SapTableHeaderCell::SUBCONTROL_ID) => Some(SapTableCellDefWrapper::Header(
+                SapTableHeaderCellDef::new_dynamic(table_def, subct_value.id()?.to_owned()),
+            )),
+            Some(SapTableHierarchicalCell::SUBCONTROL_ID) => Some(
+                SapTableCellDefWrapper::Hierarchical(SapTableHierarchicalCellDef::new_dynamic(
                     table_def,
                     subct_value.id()?.to_owned(),
-                )))
-            }
-            Some(SapTableHeaderCell::SUBCONTROL_ID) => {
-                Some(SapTableCellDefWrapper::Header(SubElementDef::<
-                    _,
-                    SapTableHeaderCell,
-                >::new_dynamic(
-                    table_def,
-                    subct_value.id()?.to_owned(),
-                )))
-            }
-            Some(SapTableHierarchicalCell::SUBCONTROL_ID) => {
-                Some(SapTableCellDefWrapper::Hierarchical(SubElementDef::<
-                    _,
-                    SapTableHierarchicalCell,
-                >::new_dynamic(
-                    table_def,
-                    subct_value.id()?.to_owned(),
-                )))
-            }
-            Some(SapTableMatrixCell::SUBCONTROL_ID) => {
-                Some(SapTableCellDefWrapper::Matrix(SubElementDef::<
-                    _,
-                    SapTableMatrixCell,
-                >::new_dynamic(
-                    table_def,
-                    subct_value.id()?.to_owned(),
-                )))
-            }
-            Some(SapTableSelectionCell::SUBCONTROL_ID) => {
-                Some(SapTableCellDefWrapper::Selection(SubElementDef::<
-                    _,
-                    SapTableSelectionCell,
-                >::new_dynamic(
-                    table_def,
-                    subct_value.id()?.to_owned(),
-                )))
-            }
+                )),
+            ),
+            Some(SapTableMatrixCell::SUBCONTROL_ID) => Some(SapTableCellDefWrapper::Matrix(
+                SapTableMatrixCellDef::new_dynamic(table_def, subct_value.id()?.to_owned()),
+            )),
+            Some(SapTableSelectionCell::SUBCONTROL_ID) => Some(SapTableCellDefWrapper::Selection(
+                SapTableSelectionCellDef::new_dynamic(table_def, subct_value.id()?.to_owned()),
+            )),
             _ => None,
         }
     }
 
     /// [`Body`]에서 서브 엘리먼트를 가져옵니다.
-    pub fn from_body(self, body: &'a Body) -> Result<SapTableCellWrapper<'a>, WebDynproError> {
+    pub fn from_body(self, body: &Body) -> Result<SapTableCellWrapper, WebDynproError> {
         match self {
             Self::Normal(def) => Ok(def.from_body(body)?.wrap()),
             Self::Header(def) => Ok(def.from_body(body)?.wrap()),
             Self::Hierarchical(def) => Ok(def.from_body(body)?.wrap()),
             Self::Matrix(def) => Ok(def.from_body(body)?.wrap()),
-            Self::Selection(def) => Ok(def.from_body(body)?.wrap())
+            Self::Selection(def) => Ok(def.from_body(body)?.wrap()),
         }
     }
 
     /// [`scraper::ElementRef`]에서 서브 엘리먼트를 가져옵니다.
-    pub fn from_elem(self, element: scraper::ElementRef<'a>) -> Result<SapTableCellWrapper<'a>, WebDynproError> {
+    pub fn from_element(
+        self,
+        element: scraper::ElementRef<'_>,
+    ) -> Result<SapTableCellWrapper, WebDynproError> {
         match self {
-            Self::Normal(def) => Ok(def.from_elem(element)?.wrap()),
-            Self::Header(def) => Ok(def.from_elem(element)?.wrap()),
-            Self::Hierarchical(def) => Ok(def.from_elem(element)?.wrap()),
-            Self::Matrix(def) => Ok(def.from_elem(element)?.wrap()),
-            Self::Selection(def) => Ok(def.from_elem(element)?.wrap())
+            Self::Normal(def) => Ok(def.from_element(element)?.wrap()),
+            Self::Header(def) => Ok(def.from_element(element)?.wrap()),
+            Self::Hierarchical(def) => Ok(def.from_element(element)?.wrap()),
+            Self::Matrix(def) => Ok(def.from_element(element)?.wrap()),
+            Self::Selection(def) => Ok(def.from_element(element)?.wrap()),
         }
     }
 }
@@ -195,10 +173,14 @@ mod matrix_cell;
 mod normal_cell;
 mod selection_cell;
 
-pub use self::header_cell::{SapTableHeaderCell, SapTableHeaderCellLSData};
-pub use self::hierarchical_cell::{SapTableHierarchicalCell, SapTableHierarchicalCellLSData};
-pub use self::matrix_cell::{SapTableMatrixCell, SapTableMatrixCellLSData};
-pub use self::normal_cell::{SapTableNormalCell, SapTableNormalCellLSData};
-pub use self::selection_cell::{SapTableSelectionCell, SapTableSelectionCellLSData};
+pub use self::header_cell::{SapTableHeaderCell, SapTableHeaderCellDef, SapTableHeaderCellLSData};
+pub use self::hierarchical_cell::{
+    SapTableHierarchicalCell, SapTableHierarchicalCellDef, SapTableHierarchicalCellLSData,
+};
+pub use self::matrix_cell::{SapTableMatrixCell, SapTableMatrixCellDef, SapTableMatrixCellLSData};
+pub use self::normal_cell::{SapTableNormalCell, SapTableNormalCellDef, SapTableNormalCellLSData};
+pub use self::selection_cell::{
+    SapTableSelectionCell, SapTableSelectionCellDef, SapTableSelectionCellLSData,
+};
 
-use super::SapTable;
+use super::{SapTable, SapTableDef};

--- a/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/normal_cell.rs
@@ -2,26 +2,24 @@ use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 
-use crate::webdynpro::{
-    element::{
-        complex::sap_table::property::{SapTableCellDesign, SapTableCellType}, define_lsdata, Element, ElementDefWrapper, SubElement, SubElementDef
-    },
-    error::WebDynproError,
+use crate::webdynpro::element::{
+    complex::{sap_table::{
+        property::{SapTableCellDesign, SapTableCellType},
+        SapTableDef,
+    }, SapTable},
+    sub::define_subelement,
+    ElementDefWrapper,
 };
 
 use super::{SapTableCell, SapTableCellWrapper};
 
-/// 일반 테이블 셀
-#[derive(custom_debug_derive::Debug)]
-pub struct SapTableNormalCell<'a> {
-    id: Cow<'static, str>,
-    #[debug(skip)]
-    element_ref: scraper::ElementRef<'a>,
-    lsdata: OnceCell<SapTableNormalCellLSData>,
-    content: OnceCell<Option<ElementDefWrapper<'a>>>,
-}
-
-define_lsdata! {
+define_subelement! {
+    #[doc = "일반 [`SapTable`] 셀"]
+    SapTableNormalCell<SapTable, SapTableDef, "STC", "SapTableNormalCell"> {
+        content: OnceCell<Option<ElementDefWrapper<'a>>>,
+    },
+    #[doc = "[`SapTableNormalCell`]의 정의"]
+    SapTableNormalCellDef,
     #[doc = "[`SapTableNormalCell`] 내부 데이터"]
     SapTableNormalCellLSData {
         is_selected: bool => "0",
@@ -47,39 +45,8 @@ impl<'a> SapTableCell<'a> for SapTableNormalCell<'a> {
                         .to_owned(),
                 )
                 .ok()
-            }).to_owned()
-    }
-}
-
-impl<'a> SubElement<'a> for SapTableNormalCell<'a> {
-    const SUBCONTROL_ID: &'static str = "STC";
-    const ELEMENT_NAME: &'static str = "SapTableNormalCell";
-
-    type SubElementLSData = SapTableNormalCellLSData;
-
-    fn lsdata(&self) -> &Self::SubElementLSData {
-        self.lsdata.get_or_init(|| {
-            let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
-                return Self::SubElementLSData::default();
-            };
-            serde_json::from_value::<Self::SubElementLSData>(lsdata_obj)
-                .unwrap_or(Self::SubElementLSData::default())
-        })
-    }
-
-    fn from_elem<Parent: Element<'a>>(
-        elem_def: SubElementDef<'a, Parent, Self>,
-        element: scraper::ElementRef<'a>,
-    ) -> Result<Self, WebDynproError> {
-        Ok(Self::new(elem_def.id_cow(), element))
-    }
-
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn element_ref(&self) -> &scraper::ElementRef<'a> {
-        &self.element_ref
+            })
+            .to_owned()
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
+++ b/src/webdynpro/element/complex/sap_table/cell/selection_cell.rs
@@ -2,26 +2,21 @@ use std::{borrow::Cow, cell::OnceCell};
 
 use scraper::Selector;
 
-use crate::webdynpro::{
-    element::{
-        complex::sap_table::property::SapTableCellType, define_lsdata, Element, ElementDefWrapper, SubElement, SubElementDef,
-    },
-    error::WebDynproError,
+use crate::webdynpro::element::{
+    complex::{sap_table::{property::SapTableCellType, SapTableDef}, SapTable},
+    sub::define_subelement,
+    ElementDefWrapper,
 };
 
 use super::{SapTableCell, SapTableCellWrapper};
 
-/// 선택 가능한 테이블 셀
-#[derive(custom_debug_derive::Debug)]
-pub struct SapTableSelectionCell<'a> {
-    id: Cow<'static, str>,
-    #[debug(skip)]
-    element_ref: scraper::ElementRef<'a>,
-    lsdata: OnceCell<SapTableSelectionCellLSData>,
-    content: OnceCell<Option<ElementDefWrapper<'a>>>,
-}
-
-define_lsdata! {
+define_subelement! {
+    #[doc = "선택 가능한 [`SapTable`]의 셀"]
+    SapTableSelectionCell<SapTable, SapTableDef, "SC", "SapTableSelectionCell"> {
+        content: OnceCell<Option<ElementDefWrapper<'a>>>,
+    },
+    #[doc = "[`SapTableSelectionCell`]의 정의"]
+    SapTableSelectionCellDef,
     #[doc = "[`SapTableSelectionCell`] 내부 데이터"]
     SapTableSelectionCellLSData {
         is_selected: bool => "0",
@@ -49,38 +44,6 @@ impl<'a> SapTableCell<'a> for SapTableSelectionCell<'a> {
                 .ok()
             })
             .to_owned()
-    }
-}
-
-impl<'a> SubElement<'a> for SapTableSelectionCell<'a> {
-    const SUBCONTROL_ID: &'static str = "SC";
-    const ELEMENT_NAME: &'static str = "SapTableSelectionCell";
-
-    type SubElementLSData = SapTableSelectionCellLSData;
-
-    fn lsdata(&self) -> &Self::SubElementLSData {
-        self.lsdata.get_or_init(|| {
-            let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
-                return Self::SubElementLSData::default();
-            };
-            serde_json::from_value::<Self::SubElementLSData>(lsdata_obj)
-                .unwrap_or(Self::SubElementLSData::default())
-        })
-    }
-
-    fn from_elem<Parent: Element<'a>>(
-        elem_def: SubElementDef<'a, Parent, Self>,
-        element: scraper::ElementRef<'a>,
-    ) -> Result<Self, WebDynproError> {
-        Ok(Self::new(elem_def.id_cow(), element))
-    }
-
-    fn id(&self) -> &str {
-        &self.id
-    }
-
-    fn element_ref(&self) -> &scraper::ElementRef<'a> {
-        &self.element_ref
     }
 }
 

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 use scraper::Selector;
 
 use crate::webdynpro::{
-    element::{define_element_interactable, ElementDef, Interactable},
+    element::{define_element_interactable, definition::ElementDefinition, Interactable},
     error::{BodyError, ElementError, WebDynproError},
     event::Event,
 };
@@ -15,6 +15,8 @@ define_element_interactable! {
     SapTable<"ST", "SapTable"> {
         table: OnceCell<Option<SapTableBody<'a>>>,
     },
+    #[doc = "[`SapTable`]의 정의"]
+    SapTableDef,
     #[doc = "[`SapTable`] 내부 데이터"]
     SapTableLSData {
         title_text: String => "0",
@@ -48,11 +50,11 @@ impl<'a> SapTable<'a> {
     }
 
     fn parse_table(&self) -> Result<SapTableBody<'a>, WebDynproError> {
-        let def: ElementDef<'a, SapTable<'a>> = {
+        let def: SapTableDef = {
             if let Cow::Borrowed(id) = self.id {
-                ElementDef::new(id)
+                SapTableDef::new(id)
             } else {
-                ElementDef::new_dynamic((&self.id).to_string())
+                SapTableDef::new_dynamic((&self.id).to_string())
             }
         };
         let element = self.element_ref;

--- a/src/webdynpro/element/graphic/image.rs
+++ b/src/webdynpro/element/graphic/image.rs
@@ -27,6 +27,8 @@ pub mod property {
 define_element_interactable! {
     #[doc = "HTML 이미지"]
     Image<"IMG", "Image"> {},
+    #[doc = "[`Image`]의 정의"]
+    ImageDef,
     #[doc = "[`Image`] 내부 데이터"]
     ImageLSData {
         tooltip: String => "0",

--- a/src/webdynpro/element/graphic/mod.rs
+++ b/src/webdynpro/element/graphic/mod.rs
@@ -1,3 +1,3 @@
 mod image;
 
-pub use image::{Image, ImageLSData};
+pub use image::{Image, ImageDef, ImageLSData};

--- a/src/webdynpro/element/layout/button_row.rs
+++ b/src/webdynpro/element/layout/button_row.rs
@@ -2,14 +2,17 @@ use scraper::Selector;
 use std::{borrow::Cow, cell::OnceCell};
 
 use crate::webdynpro::element::{
-    action::Button, define_element_base, definition::ElementDef, property::Visibility
+    action::Button, define_element_base, definition::ElementDefinition, property::Visibility,
+    Element,
 };
 
 define_element_base! {
     #[doc = "[`Button`]의 나열"]
     ButtonRow<"BR", "ButtonRow"> {
-        buttons: OnceCell<Vec<ElementDef<'a, Button<'a>>>>
+        buttons: OnceCell<Vec<<Button<'a> as Element<'a>>::Def>>
     },
+    #[doc = "[`ButtonRow`]의 정의"]
+    ButtonRowDef,
     #[doc = "[`ButtonRow`] 내부 데이터"]
     ButtonRowLSData {
         visibility: Visibility => "0",
@@ -29,20 +32,22 @@ impl<'a> ButtonRow<'a> {
     }
 
     /// 내부 [`Button`]을 반환합니다.
-    pub fn buttons(&'a self) -> impl Iterator<Item = &ElementDef<'a, Button<'a>>> + ExactSizeIterator {
+    pub fn buttons(
+        &'a self,
+    ) -> impl Iterator<Item = &<Button<'a> as Element<'a>>::Def> + ExactSizeIterator {
         self.buttons
             .get_or_init(|| {
                 let button_selector = &Selector::parse(r#":root [ct="B"]"#).unwrap();
                 self.element_ref
                     .select(button_selector)
                     .filter_map(|elem| {
-                        let def = ElementDef::from_element_ref(elem);
+                        let def = <Button<'a> as Element<'a>>::Def::from_element_ref(elem);
                         match def {
                             Ok(button_def) => Some(button_def),
-                            _ => None
+                            _ => None,
                         }
                     })
-                    .collect::<Vec<ElementDef<'a, Button<'a>>>>()
+                    .collect::<Vec<<Button<'a> as Element<'a>>::Def>>()
             })
             .iter()
     }

--- a/src/webdynpro/element/layout/form.rs
+++ b/src/webdynpro/element/layout/form.rs
@@ -10,6 +10,8 @@ define_element_interactable! {
     Form<"FOR", "Form"> {
         data: OnceCell<FormData>
     },
+    #[doc = "[`Form`]의 정의"]
+    FormDef,
     #[doc = "[`Form`] 내부 데이터"]
     FormLSData {
         has_event_queue: bool => "0",

--- a/src/webdynpro/element/layout/grid_layout/cell.rs
+++ b/src/webdynpro/element/layout/grid_layout/cell.rs
@@ -6,6 +6,8 @@ use crate::webdynpro::element::define_element_interactable;
 define_element_interactable! {
     #[doc = "[`GridLayout`](crate::webdynpro::element::layout::GridLayout) 내부 셀"]
     GridLayoutCell<"GLC", "GridLayoutCell"> {},
+    #[doc = "[`GridLayoutCell`]의 정의"]
+    GridLayoutCellDef,
     #[doc = "[`GridLayoutCell`] 내부 데이터"]
     GridLayoutCellLSData {
         drag_data: String => "0",

--- a/src/webdynpro/element/layout/grid_layout/mod.rs
+++ b/src/webdynpro/element/layout/grid_layout/mod.rs
@@ -6,6 +6,8 @@ use crate::webdynpro::element::define_element_interactable;
 define_element_interactable! {
     #[doc = "HTML `grid` 레이아웃"]
     GridLayout<"GL", "GridLayout"> {},
+    #[doc = "[`GridLayout`]의 정의"]
+    GridLayoutDef,
     #[doc = "[`GridLayout`] 내부 데이터"]
     GridLayoutLSData {
         height: String => "0",

--- a/src/webdynpro/element/layout/mod.rs
+++ b/src/webdynpro/element/layout/mod.rs
@@ -6,6 +6,8 @@ use super::property::{LockedDesign, Visibility};
 define_element_base! {
     #[doc = "HTML `flow` 레이아웃"]
     FlowLayout<"FL", "FlowLayout"> {},
+    #[doc = "[`FlowLayout`]의 정의"]
+    FlowLayoutDef,
     #[doc = "[`FlowLayout`] 내부 데이터"]
     FlowLayoutLSData {
         visibility: Visibility => "0",
@@ -27,6 +29,8 @@ impl<'a> FlowLayout<'a> {
 define_element_base! {
     #[doc = "가상 컨테이너"]
     Container<"CO", "Container"> {},
+    #[doc = "[`Container`]의 정의"]
+    ContainerDef,
     #[doc = "[`Container`] 내부 데이터"]
     ContainerLSData {
         locked: bool => "0",
@@ -56,9 +60,9 @@ pub mod grid_layout;
 pub mod tab_strip;
 
 #[doc(inline)]
-pub use self::grid_layout::{GridLayout, GridLayoutLSData};
+pub use self::grid_layout::{GridLayout, GridLayoutDef, GridLayoutLSData};
 #[doc(inline)]
-pub use self::tab_strip::{TabStrip, TabStripLSData};
+pub use self::tab_strip::{TabStrip, TabStripDef, TabStripLSData};
 
 mod button_row;
 mod form;
@@ -67,9 +71,9 @@ mod scroll_container;
 mod scrollbar;
 mod tray;
 
-pub use self::button_row::{ButtonRow, ButtonRowLSData};
-pub use self::form::{Form, FormData, FormLSData};
-pub use self::popup_window::{PopupWindow, PopupWindowLSData};
-pub use self::scroll_container::{ScrollContainer, ScrollContainerLSData};
-pub use self::scrollbar::{Scrollbar, ScrollbarLSData};
-pub use self::tray::{Tray, TrayLSData};
+pub use self::button_row::{ButtonRow, ButtonRowDef, ButtonRowLSData};
+pub use self::form::{Form, FormData, FormDef, FormLSData};
+pub use self::popup_window::{PopupWindow, PopupWindowDef, PopupWindowLSData};
+pub use self::scroll_container::{ScrollContainer, ScrollContainerDef, ScrollContainerLSData};
+pub use self::scrollbar::{Scrollbar, ScrollbarDef, ScrollbarLSData};
+pub use self::tray::{Tray, TrayDef, TrayLSData};

--- a/src/webdynpro/element/layout/popup_window.rs
+++ b/src/webdynpro/element/layout/popup_window.rs
@@ -10,6 +10,8 @@ use crate::webdynpro::element::{define_element_interactable, Interactable};
 define_element_interactable! {
     #[doc = "브라우저 창 내부에 모달 등의 팝업으로 표시되는 창"]
     PopupWindow<"PW", "PopupWindow"> {},
+    #[doc = "[`PopupWindow`]의 정의"]
+    PopupWindowDef,
     #[doc = "[`PopupWindow`] 내부 데이터"]
     PopupWindowLSData {
         is_resizable: bool => "0",

--- a/src/webdynpro/element/layout/scroll_container.rs
+++ b/src/webdynpro/element/layout/scroll_container.rs
@@ -9,6 +9,8 @@ use crate::webdynpro::element::{
 define_element_interactable! {
     #[doc = "스크롤을 처리하는 컨테이너"]
     ScrollContainer<"SC", "ScrollContainer"> {},
+    #[doc = "[`ScrollContainer`]의 정의"]
+    ScrollContainerDef,
     #[doc = "[`ScrollContainer`] 내부 데이터"]
     ScrollContainerLSData {
         scrolling_mode: ScrollingMode => "0",

--- a/src/webdynpro/element/layout/scrollbar.rs
+++ b/src/webdynpro/element/layout/scrollbar.rs
@@ -18,6 +18,8 @@ pub mod property {
 define_element_interactable! {
     #[doc = "스크롤을 수행하는 스크롤 바"]
     Scrollbar<"SCB", "Scrollbar"> {},
+    #[doc = "[`Scrollbar`]의 정의"]
+    ScrollbarDef,
     #[doc = "[`Scrollbar`] 내부 데이터"]
     ScrollbarLSData {
         value: i32 => "0",

--- a/src/webdynpro/element/layout/tab_strip/item.rs
+++ b/src/webdynpro/element/layout/tab_strip/item.rs
@@ -6,6 +6,8 @@ define_element_base! {
     // Note: This element renders as "TSITM_ie6" if >= IE6
     #[doc = "[`TabStrip`](crate::webdynpro::element::layout::TabStrip) 내부 아이템"]
     TabStripItem<"TSITM_standards", "TabStripTab"> {},
+    #[doc = "[`TabStripItem`]의 정의"]
+    TabStripItemDef,
     #[doc = "[`TabStripItem`] 내부 데이터"]
     TabStripItemLSData {
         id: String => "0",

--- a/src/webdynpro/element/layout/tab_strip/mod.rs
+++ b/src/webdynpro/element/layout/tab_strip/mod.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 use scraper::Selector;
 
 use crate::webdynpro::{
-    element::{define_element_interactable, Element, ElementDef, Interactable},
+    element::{define_element_interactable, definition::ElementDefinition, Element, Interactable},
     error::{BodyError, WebDynproError},
     event::Event,
 };
@@ -16,8 +16,10 @@ define_element_interactable! {
     #[doc = ""]
     #[doc = "> |**참고**| 이 엘리먼트는 실제 구현에서 >= IE6 용 구현과 기본 구현으로 나누어져 있지만, rusaint에서는 최신의 브라우저를 기준으로 하므로 전자의 구현은 구현되어있지 않습니다."]
     TabStrip<"TS_standards", "TabStrip"> {
-        tab_items: OnceCell<Vec<ElementDef<'a, TabStripItem<'a>>>>,
+        tab_items: OnceCell<Vec<<TabStripItem<'a> as Element<'a>>::Def>>,
     },
+    #[doc = "[`TabStrip`]의 정의"]
+    TabStripDef,
     #[doc = "[`TabStrip`] 내부 데이터"]
     TabStripLSData {
         current_index: i32 => "0",
@@ -54,7 +56,7 @@ impl<'a> TabStrip<'a> {
     /// 탭 내부 [`TabStripItem`]을 반환합니다.
     pub fn tab_items(
         &self,
-    ) -> impl Iterator<Item = &ElementDef<'a, TabStripItem<'a>>> + ExactSizeIterator {
+    ) -> impl Iterator<Item = &<TabStripItem<'a> as Element<'a>>::Def> + ExactSizeIterator {
         self.tab_items
             .get_or_init(|| {
                 let Ok(items_selector) =
@@ -67,7 +69,9 @@ impl<'a> TabStrip<'a> {
                     .select(&items_selector)
                     .filter_map(|eref| {
                         let id = eref.value().id()?;
-                        Some(ElementDef::<TabStripItem>::new_dynamic(id.to_owned()))
+                        Some(<TabStripItem<'a> as Element<'a>>::Def::new_dynamic(
+                            id.to_owned(),
+                        ))
                     })
                     .collect()
             })

--- a/src/webdynpro/element/layout/tray.rs
+++ b/src/webdynpro/element/layout/tray.rs
@@ -22,6 +22,8 @@ pub mod property {
 define_element_interactable! {
     #[doc = "열고 닫을 수 있는 트레이"]
     Tray<"TY", "Tray"> {},
+    #[doc = "[`Tray`]의 정의"]
+    TrayDef,
     #[doc = "[`Tray`] 내부 데이터"]
     TrayLSData {
         title: String => "0",

--- a/src/webdynpro/element/mod.rs
+++ b/src/webdynpro/element/mod.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use scraper::ElementRef;
 use serde_json::{Map, Value};
 
-use self::{action::{Button, Link}, complex::SapTable, definition::{sub::SubElementDef, ElementDef}, graphic::Image, layout::{grid_layout::cell::GridLayoutCell, tab_strip::item::TabStripItem, ButtonRow, Container, FlowLayout, Form, GridLayout, PopupWindow, ScrollContainer, Scrollbar, TabStrip, Tray}, selection::{list_box::{item::{ListBoxActionItem, ListBoxItem}, ListBoxMultiple, ListBoxPopup, ListBoxPopupFiltered, ListBoxPopupJson, ListBoxPopupJsonFiltered, ListBoxSingle}, ComboBox}, system::{ClientInspector, Custom, LoadingPlaceholder}, text::{Caption, InputField, Label, TextView}};
+use self::{action::{Button, Link}, complex::SapTable, definition::ElementDefinition, graphic::Image, layout::{grid_layout::cell::GridLayoutCell, tab_strip::item::TabStripItem, ButtonRow, Container, FlowLayout, Form, GridLayout, PopupWindow, ScrollContainer, Scrollbar, TabStrip, Tray}, selection::{list_box::{item::{ListBoxActionItem, ListBoxItem}, ListBoxMultiple, ListBoxPopup, ListBoxPopupFiltered, ListBoxPopupJson, ListBoxPopupJsonFiltered, ListBoxSingle}, ComboBox}, system::{ClientInspector, Custom, LoadingPlaceholder}, text::{Caption, InputField, Label, TextView}};
 
 use super::{event::{ucf_parameters::UcfParameters, Event, EventBuilder}, error::{ElementError, BodyError, WebDynproError}, client::body::Body};
 
@@ -71,6 +71,8 @@ macro_rules! define_element_base {
         $name:ident<$controlid:literal, $element_name:literal> {
             $($sfield:ident : $stype:ty),* $(,)?
         },
+        $(#[$def_outer:meta])*
+        $def_name:ident,
         $(#[$lsdata_outer:meta])*
         $lsdata:ident {
             $(
@@ -79,6 +81,62 @@ macro_rules! define_element_base {
             ),* $(,)?
         }
     } => {
+
+        $(#[$def_outer])*
+        #[derive(Clone, Debug)]
+        pub struct $def_name {
+            id: std::borrow::Cow<'static, str>,
+            node_id: Option<crate::webdynpro::element::definition::ElementNodeId>
+        }
+
+        impl $def_name {
+            /// 엘리먼트 정의를 생성합니다. 이 함수를 직접 실행하기보다는 [`define_elements`]매크로 사용을 추천합니다.
+            pub const fn new(id: &'static str) -> Self {
+                Self {
+                    id: std::borrow::Cow::Borrowed(id),
+                    node_id: None
+                }
+            }
+        }
+
+        impl<'body> $crate::webdynpro::element::definition::ElementDefinition<'body> for $def_name {
+            type Element = $name<'body>;
+            
+            fn new_dynamic(id: String) -> Self {
+                Self {
+                    id: id.into(),
+                    node_id: None
+                }
+            }
+
+            fn from_element_ref(element_ref: scraper::ElementRef<'_>) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
+                let id = element_ref.value().id().ok_or($crate::webdynpro::error::BodyError::InvalidElement)?;
+                Ok(Self {
+                    id: id.to_string().into(),
+                    node_id: None
+                })
+            }
+
+            fn with_node_id(id: String, body_hash: u64, node_id: ego_tree::NodeId) -> Self {
+                Self {
+                    id: id.into(),
+                    node_id: Some($crate::webdynpro::element::definition::ElementNodeId::new(body_hash, node_id))
+                }
+            }
+
+            fn id(&self) -> &str {
+                &self.id
+            }
+
+            fn id_cow(&self) -> Cow<'static, str> {
+                self.id.clone()
+            }
+
+            fn node_id(&self) -> Option<&$crate::webdynpro::element::definition::ElementNodeId> {
+                (&self.node_id).as_ref()
+            }
+        }
+
         $(#[$outer])*
         #[derive(custom_debug_derive::Debug)]
         #[allow(unused)]
@@ -97,21 +155,23 @@ macro_rules! define_element_base {
 
             type ElementLSData = $lsdata;
 
+            type Def = $def_name;
+
             fn lsdata(&self) -> &Self::ElementLSData {
                 self.lsdata
                     .get_or_init(|| {
-                        let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
+                        let Ok(lsdata_obj) = Self::lsdata_element(self.element_ref) else {
                             return $lsdata::default();
                         };
                         serde_json::from_value::<Self::ElementLSData>(lsdata_obj).ok().unwrap_or($lsdata::default())
                     })
             }
 
-            fn from_elem(
-                elem_def: &$crate::webdynpro::element::definition::ElementDef<'a, Self>,
+            fn from_element(
+                element_def: &impl $crate::webdynpro::element::definition::ElementDefinition<'a>,
                 element: scraper::ElementRef<'a>,
             ) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
-                Ok(Self::new(elem_def.id_cow(), element))
+                Ok(Self::new($crate::webdynpro::element::definition::ElementDefinition::id_cow(element_def), element))
             }
 
             fn id(&self) -> &str {
@@ -127,7 +187,7 @@ macro_rules! define_element_base {
             }
 
             fn children(&self) -> Vec<$crate::webdynpro::element::ElementWrapper<'a>> {
-                Self::children_elem(self.element_ref().clone())
+                Self::children_element(self.element_ref().clone())
             }
         }
         
@@ -149,6 +209,8 @@ macro_rules! define_element_interactable {
         $name:ident<$controlid:literal, $element_name:literal> {
             $($sfield:ident : $stype:ty),* $(,)?
         },
+        $(#[$def_outer:meta])*
+        $def_name:ident,
         $(#[$lsdata_outer:meta])*
         $lsdata:ident {
             $(
@@ -163,6 +225,8 @@ macro_rules! define_element_interactable {
                 lsevents: std::cell::OnceCell<Option<$crate::webdynpro::element::EventParameterMap>>,
                 $($sfield : $stype, )*
             },
+            $(#[$def_outer])*
+            $def_name,
             $(#[$lsdata_outer])*
             $lsdata {
                 $(
@@ -175,7 +239,7 @@ macro_rules! define_element_interactable {
         impl<'a> $crate::webdynpro::element::Interactable<'a> for $name<'a> {
             fn lsevents(&self) -> Option<&$crate::webdynpro::element::EventParameterMap> {
                 self.lsevents
-                    .get_or_init(|| Self::lsevents_elem(self.element_ref).ok())
+                    .get_or_init(|| Self::lsevents_element(self.element_ref).ok())
                     .as_ref()
             }
         }
@@ -215,13 +279,13 @@ macro_rules! register_elements {
 
         impl<'a> ElementWrapper<'a> {
         	/// 분류를 알 수 없는 엘리먼트의 `scraper::ElementRef`로 [`ElementWrapper`]를 반환합니다.
-            pub fn dyn_elem(element: scraper::ElementRef<'a>) -> Result<ElementWrapper, WebDynproError> {
+            pub fn dyn_element(element: scraper::ElementRef<'a>) -> Result<ElementWrapper, WebDynproError> {
                 let value = element.value();
                 let id = value.id().ok_or(BodyError::NoSuchAttribute("id".to_owned()))?.to_owned();
                 #[allow(unreachable_patterns)]
                 match element.value().attr("ct") {
-                    $( Some(<$type>::CONTROL_ID) => Ok($crate::webdynpro::element::definition::ElementDef::<$type>::new_dynamic(id).from_elem(element)?.wrap()), )*
-                    _ => Ok($crate::webdynpro::element::definition::ElementDef::<$crate::webdynpro::element::unknown::Unknown>::new_dynamic(id).from_elem(element)?.wrap())
+                    $( Some(<$type>::CONTROL_ID) => Ok(<$type as $crate::webdynpro::element::Element<'a>>::Def::new_dynamic(id).from_element(element)?.wrap()), )*
+                    _ => Ok(<$crate::webdynpro::element::unknown::Unknown as $crate::webdynpro::element::Element<'a>>::Def::new_dynamic(id).from_element(element)?.wrap())
                 }
             }
         }
@@ -243,8 +307,8 @@ macro_rules! register_elements {
         #[allow(missing_docs)]
         #[derive(Clone, Debug)]
         pub enum ElementDefWrapper<'a> {
-            $( $enum($crate::webdynpro::element::definition::ElementDef::<'a, $type>), )*
-            Unknown($crate::webdynpro::element::definition::ElementDef::<'a, $crate::webdynpro::element::unknown::Unknown<'a>>)
+            $( $enum(<$type as $crate::webdynpro::element::Element<'a>>::Def), )*
+            Unknown(<$crate::webdynpro::element::unknown::Unknown<'a> as $crate::webdynpro::element::Element<'a>>::Def)
         }
 
         impl<'a> ElementDefWrapper<'a> {
@@ -254,8 +318,8 @@ macro_rules! register_elements {
                 let id = value.id().ok_or(BodyError::NoSuchAttribute("id".to_owned()))?.to_owned();
                 #[allow(unreachable_patterns)]
                 match element.value().attr("ct") {
-                    $( Some(<$type>::CONTROL_ID) => Ok(ElementDefWrapper::$enum($crate::webdynpro::element::definition::ElementDef::<$type>::new_dynamic(id))), )*
-                    _ => Ok(ElementDefWrapper::Unknown($crate::webdynpro::element::definition::ElementDef::<$crate::webdynpro::element::unknown::Unknown>::new_dynamic(id)))
+                    $( Some(<$type>::CONTROL_ID) => Ok(ElementDefWrapper::$enum(<$type as $crate::webdynpro::element::Element<'a>>::Def::new_dynamic(id))), )*
+                    _ => Ok(ElementDefWrapper::Unknown(<$crate::webdynpro::element::unknown::Unknown<'a> as $crate::webdynpro::element::Element<'a>>::Def::new_dynamic(id)))
                 }
             }
         }
@@ -321,7 +385,7 @@ macro_rules! define_elements {
     ;)+) => {
         $(
             $(#[$attr])*
-            $v const $name: $crate::webdynpro::element::definition::ElementDef<$lt, $eltype<$lt>> = $crate::webdynpro::element::definition::ElementDef::new($id);
+            $v const $name: <$eltype<$lt> as $crate::webdynpro::element::Element<$lt>>::Def = <$eltype<$lt> as $crate::webdynpro::element::Element<$lt>>::Def::new($id);
         )*
     };
     ($(
@@ -330,7 +394,7 @@ macro_rules! define_elements {
     ;)+) => {
         $(
             $(#[$attr])*
-            const $name: $crate::webdynpro::element::definition::ElementDef<$lt, $eltype<$lt>> = $crate::webdynpro::element::definition::ElementDef::new($id);
+            const $name: <$eltype<$lt> as $crate::webdynpro::element::Element<$lt>>::Def = <$eltype<$lt> as $crate::webdynpro::element::Element<$lt>>::Def::new($id);
         )*
     }
 }
@@ -354,25 +418,28 @@ pub trait Element<'a>: Sized {
     const CONTROL_ID: &'static str;
     /// WebDynpro 상에서 사용하는 엘리먼트의 이름
     const ELEMENT_NAME: &'static str;
-/// 엘리먼트의 LSData
+    /// 엘리먼트의 LSData
     type ElementLSData;
+
+    /// 엘리먼트의 정의
+    type Def: ElementDefinition<'a>;
 	
     /// 엘리먼트의 JSON 객체 형태의 LSData를 반환합니다.
-    fn lsdata_elem(element: scraper::ElementRef) -> Result<Value, WebDynproError> {
+    fn lsdata_element(element: scraper::ElementRef) -> Result<Value, WebDynproError> {
         let raw_data = element.value().attr("lsdata").ok_or(ElementError::InvalidLSData(element.value().id().unwrap().to_string()))?;
         let normalized = normalize_lsjson(raw_data);
         return Ok(serde_json::from_str(&normalized).or(Err(ElementError::InvalidLSData(element.value().id().unwrap().to_string())))?);
     }
 
 	/// 엘리먼트 정의와 [`Body`]에서 엘리먼트를 가져옵니다.
-    fn from_body(elem_def: &ElementDef<'a, Self>, body: &'a Body) -> Result<Self, WebDynproError> {
+    fn from_body(elem_def: &impl ElementDefinition<'a>, body: &'a Body) -> Result<Self, WebDynproError> {
         if let Some(node_id) = elem_def.node_id() {
             let mut hasher = DefaultHasher::new();
             body.hash(&mut hasher);
             let body_hash = hasher.finish();
             if body_hash == node_id.body_hash() {
                 if let Some(elem) = body.document().tree.get(node_id.node_id()).and_then(|node| ElementRef::wrap(node)) {
-                    return Self::from_elem(elem_def, elem)
+                    return Self::from_element(elem_def, elem)
                 }
             }
         }
@@ -382,14 +449,14 @@ pub trait Element<'a>: Sized {
             .select(selector)
             .next()
             .ok_or(ElementError::InvalidId(elem_def.id().to_owned()))?;
-        Self::from_elem(elem_def, element)
+        Self::from_element(elem_def, element)
     }
 
 	/// 엘리먼트 정의와 [`scraper::ElementRef`]에서 엘리먼트를 가져옵니다.
-    fn from_elem(elem_def: &ElementDef<'a, Self>, element: scraper::ElementRef<'a>) -> Result<Self, WebDynproError>;
+    fn from_element(elem_def: &impl ElementDefinition<'a>, element: scraper::ElementRef<'a>) -> Result<Self, WebDynproError>;
 
 	/// 엘리먼트의 자식 엘리먼트를 가져옵니다.
-    fn children_elem(root: scraper::ElementRef<'a>) -> Vec<ElementWrapper<'a>> {
+    fn children_element(root: scraper::ElementRef<'a>) -> Vec<ElementWrapper<'a>> {
         let mut next_refs = vec![root];
         let mut cts: Vec<ElementRef<'_>> = vec![];
         while let Some(elem) = next_refs.pop() {
@@ -405,7 +472,7 @@ pub trait Element<'a>: Sized {
                 }
             }
         }
-        cts.into_iter().rev().filter_map(|eref| ElementWrapper::dyn_elem(eref).ok()).collect()
+        cts.into_iter().rev().filter_map(|eref| ElementWrapper::dyn_element(eref).ok()).collect()
     }
 
 	/// 엘리먼트의 자식 엘리먼트를 가져옵니다.
@@ -441,7 +508,7 @@ pub trait Interactable<'a>: Element<'a> {
     }
 
 	/// 엘리먼트가 발생시킬 수 있는 이벤트와 파라메터를 가져옵니다.
-    fn lsevents_elem(element: scraper::ElementRef) -> Result<EventParameterMap, WebDynproError> {
+    fn lsevents_element(element: scraper::ElementRef) -> Result<EventParameterMap, WebDynproError> {
         let raw_data = element.value().attr("lsevents").ok_or(BodyError::Invalid("Cannot find lsevents from element".to_string()))?;
         let normalized = normalize_lsjson(raw_data);
         let json: Map<String, Value> = serde_json::from_str::<Map<String, Value>>(&normalized).or(Err(BodyError::Invalid("Cannot deserialize lsevents field".to_string())))?.to_owned();
@@ -476,48 +543,5 @@ pub trait Interactable<'a>: Element<'a> {
     fn lsevents(&self) -> Option<&EventParameterMap>;
 }
 
-/// 서브 엘리먼트의 기능
-pub trait SubElement<'a>: Sized {
-	/// WebDynpro 내부에서 사용하는 서브 엘리먼트의 Id
-    const SUBCONTROL_ID: &'static str;
-    /// WebDynpro 내부에서 사용하는 서브 엘리먼트의 이름
-    const ELEMENT_NAME: &'static str;
-    /// 서브 엘리먼트의 LSData
-    type SubElementLSData;
-
-	/// 서브 엘리먼트의 LSData를 JSON 객체 형태로 반환합니다.
-    fn lsdata_elem(element: scraper::ElementRef) -> Result<Value, WebDynproError> {
-        let raw_data = element.value().attr("lsdata").ok_or(ElementError::InvalidLSData(element.value().id().unwrap().to_string()))?;
-        let normalized = normalize_lsjson(raw_data);
-        return Ok(serde_json::from_str(&normalized).or(Err(ElementError::InvalidLSData(element.value().id().unwrap().to_string())))?);
-    }
-
-	/// 서브 엘리먼트의 정의와 [`Body`]로부터 서브 엘리먼트를 가져옵니다.
-    fn from_body<Parent: Element<'a>>(
-        elem_def: SubElementDef<'a, Parent, Self>,
-        body: &'a Body,
-    ) -> Result<Self, WebDynproError> {
-        let selector = &elem_def.selector()?;
-        let element = body
-            .document()
-            .select(selector)
-            .next()
-            .ok_or(ElementError::InvalidId(elem_def.id().to_owned()))?;
-        Self::from_elem(elem_def, element)
-    }
-
-	/// 서브 엘리먼트 정의와[] `scraper::ElementRef`]로부터 서브 엘리먼트를 가져옵니다.
-    fn from_elem<Parent: Element<'a>>(
-        elem_def: SubElementDef<'a, Parent, Self>,
-        element: scraper::ElementRef<'a>
-    ) -> Result<Self, WebDynproError>;
-
-	/// 서브 엘리먼트의 LSData를 가져옵니다.
-    fn lsdata(&self) -> &Self::SubElementLSData;
-
-	/// 서브 엘리먼트의 Id를 가져옵니다.
-    fn id(&self) -> &str;
-
-	/// 서브 엘리먼트의 [`scraper::ElementRef`]를 가져옵니다.
-    fn element_ref(&self) -> &ElementRef<'a>;
-}
+/// [`SubElement`] 트레이트 모듈
+pub mod sub;

--- a/src/webdynpro/element/selection/combo_box.rs
+++ b/src/webdynpro/element/selection/combo_box.rs
@@ -12,6 +12,8 @@ use super::list_box::ListBoxWrapper;
 define_element_interactable! {
     #[doc = "목록 혹은 직접 입력하여 선택할 수 있는 콤보 박스"]
     ComboBox<"CB", "ComboBox"> {},
+    #[doc = "[`ComboBox`]의 정의"]
+    ComboBoxDef,
     #[doc = "[`ComboBox`] 내부 데이터"]
     ComboBoxLSData {
         width: String => "0",
@@ -77,7 +79,7 @@ impl<'a> ComboBox<'a> {
             .next()
             .ok_or(BodyError::NoSuchElement(listbox_id.to_owned()))?;
         Ok(
-            ListBoxWrapper::from_elements(ElementWrapper::dyn_elem(elem)?)
+            ListBoxWrapper::from_elements(ElementWrapper::dyn_element(elem)?)
                 .ok_or(BodyError::NoSuchElement(listbox_id.to_owned()))?,
         )
     }

--- a/src/webdynpro/element/selection/list_box/item/action_item.rs
+++ b/src/webdynpro/element/selection/list_box/item/action_item.rs
@@ -8,6 +8,8 @@ define_element_base! {
         title: OnceCell<String>,
         text: OnceCell<String>,
     },
+    #[doc = "[`ListBoxActionItem`]의 정의"]
+    ListBoxActionItemDef,
     #[doc = "[`ListBoxActionItem`]의 내부 데이터"]
     ListBoxActionItemLSData {
         custom_data: String => "0",

--- a/src/webdynpro/element/selection/list_box/item/mod.rs
+++ b/src/webdynpro/element/selection/list_box/item/mod.rs
@@ -25,6 +25,8 @@ define_element_base! {
         group_title: OnceCell<Option<&'a str>>,
         title: OnceCell<&'a str>,
     },
+    #[doc = "[`ListBoxItem`]의 정의"]
+    ListBoxItemDef,
     #[doc = "[`ListBoxItem`] 내부 데이터"]
     ListBoxItemLSData {
         icon_src: String => "0",
@@ -157,4 +159,4 @@ impl<'a> ListBoxItem<'a> {
 
 mod action_item;
 
-pub use self::action_item::{ListBoxActionItem, ListBoxActionItemLSData};
+pub use self::action_item::{ListBoxActionItem, ListBoxActionItemDef, ListBoxActionItemLSData};

--- a/src/webdynpro/element/selection/mod.rs
+++ b/src/webdynpro/element/selection/mod.rs
@@ -1,6 +1,6 @@
 mod combo_box;
 
-pub use self::combo_box::{ComboBox, ComboBoxLSData};
+pub use self::combo_box::{ComboBox, ComboBoxDef, ComboBoxLSData};
 
 /// [`ListBox`](self::list_box::ListBox) 구현
 pub mod list_box;

--- a/src/webdynpro/element/sub.rs
+++ b/src/webdynpro/element/sub.rs
@@ -1,0 +1,208 @@
+macro_rules! define_subelement {
+  {   $(#[$outer:meta])*
+      $name:ident<$parent:ident, $parent_def:ty, $controlid:literal, $element_name:literal> {
+          $($sfield:ident : $stype:ty),* $(,)?
+      },
+      $(#[$def_outer:meta])*
+      $def_name:ident,
+      $(#[$lsdata_outer:meta])*
+      $lsdata:ident {
+          $(
+              $(#[$lsdata_inner:meta])*
+              $field:ident: $ftype:ty => $encoded:literal
+          ),* $(,)?
+      }
+  } => {
+
+      $(#[$def_outer])*
+      #[derive(Clone, Debug)]
+      pub struct $def_name {
+          id: std::borrow::Cow<'static, str>,
+          parent: $parent_def,
+          node_id: Option<crate::webdynpro::element::definition::ElementNodeId>
+      }
+
+      impl $def_name {
+          /// 서브 엘리먼트의 정의를 생성합니다.
+          pub const fn new(parent: $parent_def, id: &'static str) -> Self {
+              Self {
+                  id: std::borrow::Cow::Borrowed(id),
+                  parent,
+                  node_id: None
+              }
+          }
+      }
+
+      impl<'body> $crate::webdynpro::element::definition::sub::SubElementDefinition<'body> for $def_name {
+
+          type Parent = $parent<'body>;
+
+          type SubElement = $name<'body>;
+
+          fn new_dynamic(parent: <Self::Parent as $crate::webdynpro::element::Element<'body>>::Def, id: String) -> Self {
+              Self {
+                  id: id.into(),
+                  parent,
+                  node_id: None
+              }
+          }
+
+          fn from_element_ref(parent: <Self::Parent as $crate::webdynpro::element::Element<'body>>::Def, element_ref: scraper::ElementRef<'_>) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
+              let id = element_ref.value().id().ok_or($crate::webdynpro::error::BodyError::InvalidElement)?;
+              Ok(Self {
+                  id: id.to_string().into(),
+                  parent,
+                  node_id: None
+              })
+          }
+
+          fn with_node_id(id: String, parent: <Self::Parent as $crate::webdynpro::element::Element<'body>>::Def, body_hash: u64, node_id: ego_tree::NodeId) -> Self {
+              Self {
+                  id: id.into(),
+                  parent,
+                  node_id: Some($crate::webdynpro::element::definition::ElementNodeId::new(body_hash, node_id))
+              }
+          }
+
+          fn id(&self) -> &str {
+              &self.id
+          }
+
+          fn id_cow(&self) -> Cow<'static, str> {
+              self.id.clone()
+          }
+
+          fn node_id(&self) -> Option<&$crate::webdynpro::element::definition::ElementNodeId> {
+              (&self.node_id).as_ref()
+          }
+
+          fn parent(&self) -> &<Self::Parent as $crate::webdynpro::element::Element<'body>>::Def {
+            &self.parent
+          }
+      }
+
+      $(#[$outer])*
+      #[derive(custom_debug_derive::Debug)]
+      #[allow(unused)]
+      pub struct $name<'a> {
+          id: std::borrow::Cow<'static, str>,
+          #[debug(skip)]
+          element_ref: scraper::ElementRef<'a>,
+          lsdata: std::cell::OnceCell<$lsdata>,
+          $($sfield: $stype, )*
+      }
+
+      impl<'a> $crate::webdynpro::element::sub::SubElement<'a> for $name<'a> {
+          const SUBCONTROL_ID: &'static str = $controlid;
+
+          const ELEMENT_NAME: &'static str = $element_name;
+
+          type SubElementLSData = $lsdata;
+
+          type Def = $def_name;
+
+          fn lsdata(&self) -> &Self::SubElementLSData {
+              self.lsdata
+                  .get_or_init(|| {
+                      let Ok(lsdata_obj) = Self::lsdata_element(self.element_ref) else {
+                          return $lsdata::default();
+                      };
+                      serde_json::from_value::<Self::SubElementLSData>(lsdata_obj).ok().unwrap_or($lsdata::default())
+                  })
+          }
+
+          fn from_subelement(
+              element_def: &impl $crate::webdynpro::element::definition::sub::SubElementDefinition<'a>,
+              element: scraper::ElementRef<'a>,
+          ) -> Result<Self, $crate::webdynpro::error::WebDynproError> {
+              Ok(Self::new($crate::webdynpro::element::definition::sub::SubElementDefinition::id_cow(element_def), element))
+          }
+
+          fn id(&self) -> &str {
+              &self.id
+          }
+
+          fn element_ref(&self) -> &scraper::ElementRef<'a> {
+              &self.element_ref
+          }
+      }
+
+      $crate::webdynpro::element::define_lsdata! {
+          $(#[$lsdata_outer])*
+          $lsdata {
+              $(
+                  $(#[$lsdata_inner])*
+                  $field : $ftype => $encoded,
+              )+
+          }
+      }
+  };
+}
+
+pub(crate) use define_subelement;
+use scraper::ElementRef;
+use serde_json::Value;
+
+use crate::webdynpro::{
+    client::body::Body,
+    error::{ElementError, WebDynproError},
+};
+
+use super::{definition::sub::SubElementDefinition, normalize_lsjson};
+
+/// 서브 엘리먼트의 기능
+pub trait SubElement<'a>: Sized {
+    /// WebDynpro 내부에서 사용하는 서브 엘리먼트의 Id
+    const SUBCONTROL_ID: &'static str;
+    /// WebDynpro 내부에서 사용하는 서브 엘리먼트의 이름
+    const ELEMENT_NAME: &'static str;
+    /// 서브 엘리먼트의 LSData
+    type SubElementLSData;
+    /// 서브 엘리먼트의 정의
+    type Def: SubElementDefinition<'a>;
+
+    /// 서브 엘리먼트의 LSData를 JSON 객체 형태로 반환합니다.
+    fn lsdata_element(element: scraper::ElementRef) -> Result<Value, WebDynproError> {
+        let raw_data = element
+            .value()
+            .attr("lsdata")
+            .ok_or(ElementError::InvalidLSData(
+                element.value().id().unwrap().to_string(),
+            ))?;
+        let normalized = normalize_lsjson(raw_data);
+        return Ok(
+            serde_json::from_str(&normalized).or(Err(ElementError::InvalidLSData(
+                element.value().id().unwrap().to_string(),
+            )))?,
+        );
+    }
+
+    /// 서브 엘리먼트의 정의와 [`Body`]로부터 서브 엘리먼트를 가져옵니다.
+    fn from_body(
+        elem_def: &impl SubElementDefinition<'a>,
+        body: &'a Body,
+    ) -> Result<Self, WebDynproError> {
+        let selector = &elem_def.selector()?;
+        let element = body
+            .document()
+            .select(selector)
+            .next()
+            .ok_or(ElementError::InvalidId(elem_def.id().to_owned()))?;
+        Self::from_subelement(elem_def, element)
+    }
+
+    /// 서브 엘리먼트 정의와[] `scraper::ElementRef`]로부터 서브 엘리먼트를 가져옵니다.
+    fn from_subelement(
+        elem_def: &impl SubElementDefinition<'a>,
+        element: scraper::ElementRef<'a>,
+    ) -> Result<Self, WebDynproError>;
+
+    /// 서브 엘리먼트의 LSData를 가져옵니다.
+    fn lsdata(&self) -> &Self::SubElementLSData;
+
+    /// 서브 엘리먼트의 Id를 가져옵니다.
+    fn id(&self) -> &str;
+
+    /// 서브 엘리먼트의 [`scraper::ElementRef`]를 가져옵니다.
+    fn element_ref(&self) -> &ElementRef<'a>;
+}

--- a/src/webdynpro/element/system/client_inspector.rs
+++ b/src/webdynpro/element/system/client_inspector.rs
@@ -2,12 +2,11 @@ use std::{borrow::Cow, cell::OnceCell, collections::HashMap};
 
 use serde::{Deserialize, Serialize};
 
-use crate::webdynpro::error::WebDynproError;
+use crate::webdynpro::element::definition::{ElementDefinition, ElementNodeId};
+use crate::webdynpro::error::{BodyError, WebDynproError};
 use crate::webdynpro::event::Event;
 
-use crate::webdynpro::element::{
-    Element, ElementDef, ElementWrapper, EventParameterMap, Interactable,
-};
+use crate::webdynpro::element::{Element, ElementWrapper, EventParameterMap, Interactable};
 
 /// 클라이언트의 변경 사항을 감시
 ///
@@ -124,6 +123,61 @@ pub struct ClientInspectorLSData {
     parent_accessible: Option<String>,
 }
 
+#[doc = "[`ClientInspector`]의 정의"]
+#[derive(Clone, Debug)]
+pub struct ClientInspectorDef {
+    id: Cow<'static, str>,
+    node_id: Option<ElementNodeId>,
+}
+
+impl ClientInspectorDef {
+    /// 엘리먼트의 정의를 생성합니다.
+    pub const fn new(id: &'static str) -> Self {
+        Self {
+            id: Cow::Borrowed(id),
+            node_id: None,
+        }
+    }
+}
+
+impl<'body> ElementDefinition<'body> for ClientInspectorDef {
+    type Element = ClientInspector<'body>;
+
+    fn new_dynamic(id: String) -> Self {
+        Self {
+            id: id.into(),
+            node_id: None,
+        }
+    }
+
+    fn from_element_ref(element_ref: scraper::ElementRef<'_>) -> Result<Self, WebDynproError> {
+        let id = element_ref.value().id().ok_or(BodyError::InvalidElement)?;
+        Ok(Self {
+            id: id.to_string().into(),
+            node_id: None,
+        })
+    }
+
+    fn with_node_id(id: String, body_hash: u64, node_id: ego_tree::NodeId) -> Self {
+        Self {
+            id: id.into(),
+            node_id: Some(ElementNodeId::new(body_hash, node_id)),
+        }
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn id_cow(&self) -> Cow<'static, str> {
+        self.id.clone()
+    }
+
+    fn node_id(&self) -> Option<&ElementNodeId> {
+        (&self.node_id).as_ref()
+    }
+}
+
 impl<'a> Element<'a> for ClientInspector<'a> {
     const CONTROL_ID: &'static str = "CI";
 
@@ -131,9 +185,11 @@ impl<'a> Element<'a> for ClientInspector<'a> {
 
     type ElementLSData = ClientInspectorLSData;
 
+    type Def = ClientInspectorDef;
+
     fn lsdata(&self) -> &Self::ElementLSData {
         self.lsdata.get_or_init(|| {
-            let Ok(lsdata_obj) = Self::lsdata_elem(self.element_ref) else {
+            let Ok(lsdata_obj) = Self::lsdata_element(self.element_ref) else {
                 return ClientInspectorLSData::default();
             };
             serde_json::from_value::<Self::ElementLSData>(lsdata_obj)
@@ -141,8 +197,8 @@ impl<'a> Element<'a> for ClientInspector<'a> {
         })
     }
 
-    fn from_elem(
-        elem_def: &ElementDef<'a, Self>,
+    fn from_element(
+        elem_def: &impl ElementDefinition<'a>,
         element: scraper::ElementRef<'a>,
     ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id_cow(), element))
@@ -161,14 +217,14 @@ impl<'a> Element<'a> for ClientInspector<'a> {
     }
 
     fn children(&self) -> Vec<ElementWrapper<'a>> {
-        Self::children_elem(self.element_ref().clone())
+        Self::children_element(self.element_ref().clone())
     }
 }
 
 impl<'a> Interactable<'a> for ClientInspector<'a> {
     fn lsevents(&self) -> Option<&EventParameterMap> {
         self.lsevents
-            .get_or_init(|| Self::lsevents_elem(self.element_ref).ok())
+            .get_or_init(|| Self::lsevents_element(self.element_ref).ok())
             .as_ref()
     }
 }

--- a/src/webdynpro/element/system/loading_placeholder.rs
+++ b/src/webdynpro/element/system/loading_placeholder.rs
@@ -16,6 +16,8 @@ define_element_interactable! {
     #[doc = "[`Custom`]: crate::webdynpro::element::system::Custom"]
     #[doc = "[`ClientInspector`]: crate::webdynpro::element::system::ClientInspector"]
     LoadingPlaceholder<"LP", "LoadingPlaceHolder"> {},
+    #[doc = "[`LoadingPlaceholder`]의 정의"]
+    LoadingPlaceholderDef,
     #[doc = "[`LoadingPlaceholder`] 내부 데이터"]
     LoadingPlaceholderLSData {
         id: String => "0",

--- a/src/webdynpro/element/system/mod.rs
+++ b/src/webdynpro/element/system/mod.rs
@@ -2,6 +2,8 @@ mod client_inspector;
 mod custom;
 mod loading_placeholder;
 
-pub use self::client_inspector::{ClientInspector, ClientInspectorLSData};
-pub use self::custom::{Custom, CustomClientInfo};
-pub use self::loading_placeholder::{LoadingPlaceholder, LoadingPlaceholderLSData};
+pub use self::client_inspector::{ClientInspector, ClientInspectorDef, ClientInspectorLSData};
+pub use self::custom::{Custom, CustomClientInfo, CustomDef};
+pub use self::loading_placeholder::{
+    LoadingPlaceholder, LoadingPlaceholderDef, LoadingPlaceholderLSData,
+};

--- a/src/webdynpro/element/text/caption.rs
+++ b/src/webdynpro/element/text/caption.rs
@@ -11,6 +11,8 @@ define_element_interactable! {
     #[doc = "[`Tray`]: crate::webdynpro::element::layout::Tray"]
     Caption<"CP", "Caption"> {
     },
+    #[doc = "[`Caption`]의 정의"]
+    CaptionDef,
     #[doc = "[`Caption`] 내부 데이터"]
     CaptionLSData {
         tooltip: String=> "0",

--- a/src/webdynpro/element/text/input_field.rs
+++ b/src/webdynpro/element/text/input_field.rs
@@ -6,6 +6,8 @@ use crate::webdynpro::element::define_element_interactable;
 define_element_interactable! {
     #[doc = "입력 필드"]
     InputField<"I", "InputField"> {},
+    #[doc = "[`InputField`]의 정의"]
+    InputFieldDef,
     #[doc = "[`InputField`] 내부 데이터"]
     InputFieldLSData {
         value: String => "0",

--- a/src/webdynpro/element/text/label.rs
+++ b/src/webdynpro/element/text/label.rs
@@ -6,6 +6,8 @@ use crate::webdynpro::element::define_element_interactable;
 define_element_interactable! {
     #[doc = "버튼 등의 엘리먼트를 부연하는 라벨"]
     Label<"L", "Label"> {},
+    #[doc = "[`Label`]의 정의"]
+    LabelDef,
     #[doc = "[`Label`] 내부 데이터"]
     LabelLSData {
         tooltip: String => "0",

--- a/src/webdynpro/element/text/mod.rs
+++ b/src/webdynpro/element/text/mod.rs
@@ -3,7 +3,7 @@ mod input_field;
 mod label;
 mod text_view;
 
-pub use self::caption::{Caption, CaptionLSData};
-pub use self::input_field::{InputField, InputFieldLSData};
-pub use self::label::{Label, LabelLSData};
-pub use self::text_view::{TextView, TextViewLSData};
+pub use self::caption::{Caption, CaptionDef, CaptionLSData};
+pub use self::input_field::{InputField, InputFieldDef, InputFieldLSData};
+pub use self::label::{Label, LabelDef, LabelLSData};
+pub use self::text_view::{TextView, TextViewDef, TextViewLSData};

--- a/src/webdynpro/element/text/text_view.rs
+++ b/src/webdynpro/element/text/text_view.rs
@@ -7,6 +7,8 @@ define_element_interactable! {
     TextView<"TV", "TextView"> {
         text: OnceCell<String>
     },
+    #[doc = "[`TextView`]의 정의"]
+    TextViewDef,
     #[doc = "[`TextView`] 내부 데이터"]
     TextViewLSData {
         tooltip: String => "0",

--- a/src/webdynpro/element/unknown.rs
+++ b/src/webdynpro/element/unknown.rs
@@ -2,9 +2,12 @@ use std::{borrow::Cow, cell::OnceCell};
 
 use serde_json::Value;
 
-use crate::webdynpro::error::WebDynproError;
+use crate::webdynpro::error::{BodyError, WebDynproError};
 
-use super::{Element, ElementDef, EventParameterMap, Interactable};
+use super::{
+    definition::{ElementDefinition, ElementNodeId},
+    Element, EventParameterMap, Interactable,
+};
 
 // Type for unimplemented elements
 /// rusaint에 구현되지 않은 엘리먼트를 위한 가상 엘리먼트
@@ -17,6 +20,61 @@ pub struct Unknown<'a> {
     lsevents: OnceCell<Option<EventParameterMap>>,
 }
 
+/// [`Unknown`]의 정의
+#[derive(Clone, Debug)]
+pub struct UnknownDef {
+    id: Cow<'static, str>,
+    node_id: Option<ElementNodeId>,
+}
+
+impl UnknownDef {
+    /// 엘리먼트의 정의를 생성합니다.
+    pub const fn new(id: &'static str) -> Self {
+        Self {
+            id: Cow::Borrowed(id),
+            node_id: None,
+        }
+    }
+}
+
+impl<'body> ElementDefinition<'body> for UnknownDef {
+    type Element = Unknown<'body>;
+
+    fn new_dynamic(id: String) -> Self {
+        Self {
+            id: id.into(),
+            node_id: None,
+        }
+    }
+
+    fn from_element_ref(element_ref: scraper::ElementRef<'_>) -> Result<Self, WebDynproError> {
+        let id = element_ref.value().id().ok_or(BodyError::InvalidElement)?;
+        Ok(Self {
+            id: id.to_string().into(),
+            node_id: None,
+        })
+    }
+
+    fn with_node_id(id: String, body_hash: u64, node_id: ego_tree::NodeId) -> Self {
+        Self {
+            id: id.into(),
+            node_id: Some(ElementNodeId::new(body_hash, node_id)),
+        }
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn id_cow(&self) -> Cow<'static, str> {
+        self.id.clone()
+    }
+
+    fn node_id(&self) -> Option<&ElementNodeId> {
+        (&self.node_id).as_ref()
+    }
+}
+
 impl<'a> Element<'a> for Unknown<'a> {
     /// 실제로 사용하지 않는 가상의 Id
     const CONTROL_ID: &'static str = "_UNKNOWN";
@@ -25,13 +83,15 @@ impl<'a> Element<'a> for Unknown<'a> {
 
     type ElementLSData = Value;
 
+    type Def = UnknownDef;
+
     fn lsdata(&self) -> &Self::ElementLSData {
         self.lsdata
-            .get_or_init(|| Self::lsdata_elem(self.element_ref).unwrap_or(Value::default()))
+            .get_or_init(|| Self::lsdata_element(self.element_ref).unwrap_or(Value::default()))
     }
 
-    fn from_elem(
-        elem_def: &ElementDef<'a, Self>,
+    fn from_element(
+        elem_def: &impl ElementDefinition<'a>,
         element: scraper::ElementRef<'a>,
     ) -> Result<Self, WebDynproError> {
         Ok(Self::new(elem_def.id_cow(), element))
@@ -50,14 +110,14 @@ impl<'a> Element<'a> for Unknown<'a> {
     }
 
     fn children(&self) -> Vec<super::ElementWrapper<'a>> {
-        Self::children_elem(self.element_ref().clone())
+        Self::children_element(self.element_ref().clone())
     }
 }
 
 impl<'a> Interactable<'a> for Unknown<'a> {
     fn lsevents(&self) -> Option<&EventParameterMap> {
         self.lsevents
-            .get_or_init(|| Self::lsevents_elem(self.element_ref).ok())
+            .get_or_init(|| Self::lsevents_element(self.element_ref).ok())
             .as_ref()
     }
 }

--- a/tests/webdynpro/element/button.rs
+++ b/tests/webdynpro/element/button.rs
@@ -3,8 +3,7 @@ use rusaint::{
     define_elements,
     webdynpro::{
         element::{
-            action::{Button, Link},
-            text::TextView,
+            action::{Button, Link}, definition::ElementDefinition, text::TextView
         },
         error::WebDynproError,
     },


### PR DESCRIPTION
# What's in this pull request
- `ElementDef`, `SubElementDef` 구조체를 제거하고, `ElementDefinition` 과 `SubElementDefinition` 트레이트와 해당 트레이트를 구현하는 각자의 구조체로 변경했습니다(ex: `ElementDef<'_, Button<'_>>` -> `ButtonDef`)
  - 따라서 `ElementDef` 와 `SubElementDef` 사용 시 컴파일러에서 올바르지 않게 객체 수명을 추정하는 문제를 해결할 수 있을 것으로 기대합니다.
- `SubElement`를 생성하는 매크로인 `define_subelement` 를 추가하고 `SubElement` 트레이트를 직접 구현하는 구조체들에 대해 매크로를 사용하여 리팩터링했습니다.