### PR TITLE
[feat] `Chapel` 애플리케이션

### DIFF
--- a/src/application/chapel/mod.rs
+++ b/src/application/chapel/mod.rs
@@ -1,0 +1,48 @@
+use model::ChapelInformation;
+
+use crate::{
+    define_elements, model::SemesterType, webdynpro::{
+        client::body::Body, element::{action::Button, selection::ComboBox}, error::WebDynproError
+    }, RusaintError
+};
+
+use super::{USaintApplication, USaintClient};
+
+/// [채플정보조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW3681)
+pub struct Chapel {
+    client: USaintClient,
+}
+
+impl USaintApplication for Chapel {
+    const APP_NAME: &'static str = "ZCMW3681";
+
+    fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(Self { client })
+        }
+    }
+}
+
+
+impl<'a> Chapel {
+
+    define_elements! {
+        SEL_PERYR: ComboBox<'a> = "ZCMW3681.ID_0001:V_MAIN.TC_SEL_PERYR";
+        SEL_PERID: ComboBox<'a> = "ZCMW3681.ID_0001:V_MAIN.TC_SEL_PERID";
+        BTN_SEL: Button<'a> = "ZCMW3681.ID_0001:V_MAIN.BTN_SEL";
+    }
+
+    fn body(&self) -> &Body {
+        self.client.body()
+    }
+
+    pub async fn information(&mut self, year: u32, semester: SemesterType) -> Result<ChapelInformation, WebDynproError> {
+        todo!()
+    }
+
+}
+
+/// [`Chapel`] 애플리케이션에 사용되는 데이터
+pub mod model;

--- a/src/application/chapel/mod.rs
+++ b/src/application/chapel/mod.rs
@@ -1,9 +1,18 @@
 use model::{ChapelAbsenceRequest, ChapelAttendance, ChapelInformation, GeneralChapelInformation};
 
 use crate::{
-    define_elements, model::SemesterType, webdynpro::{
-        client::body::Body, command::element::{action::ButtonPressCommand, selection::{ComboBoxSelectCommand, ReadComboBoxLSDataCommand}}, element::{action::Button, selection::ComboBox}, error::{ElementError, WebDynproError}
-    }, RusaintError
+    define_elements,
+    model::SemesterType,
+    webdynpro::{
+        client::body::Body,
+        command::element::{
+            action::ButtonPressCommand,
+            selection::{ComboBoxSelectCommand, ReadComboBoxLSDataCommand},
+        },
+        element::{action::Button, selection::ComboBox},
+        error::{ElementError, WebDynproError},
+    },
+    RusaintError,
 };
 
 use super::{USaintApplication, USaintClient};
@@ -25,9 +34,7 @@ impl USaintApplication for Chapel {
     }
 }
 
-
 impl<'a> Chapel {
-
     define_elements! {
         SEL_PERYR: ComboBox<'a> = "ZCMW3681.ID_0001:V_MAIN.TC_SEL_PERYR";
         SEL_PERID: ComboBox<'a> = "ZCMW3681.ID_0001:V_MAIN.TC_SEL_PERID";
@@ -68,29 +75,43 @@ impl<'a> Chapel {
         }
         if (|| Some(semester_combobox_lsdata.key()?.as_str()))() != Some(semester) {
             self.client
-                .send(ComboBoxSelectCommand::new(
-                    Self::SEL_PERID,
-                    semester,
-                    false,
-                ))
+                .send(ComboBoxSelectCommand::new(Self::SEL_PERID, semester, false))
                 .await?;
         }
-        self.client.send(ButtonPressCommand::new(Self::BTN_SEL)).await?;
+        self.client
+            .send(ButtonPressCommand::new(Self::BTN_SEL))
+            .await?;
         Ok(())
     }
 
     // TODO: 정보가 없을 때 올바른 오류 반환
     /// 해당 학기의 채플 정보를 가져옵니다.
-    pub async fn information(&mut self, year: u32, semester: SemesterType) -> Result<ChapelInformation, WebDynproError> {
+    pub async fn information(
+        &mut self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<ChapelInformation, RusaintError> {
         self.select_semester(&year.to_string(), semester).await?;
-        let general_information = GeneralChapelInformation::from_body(self.body())?.pop().ok_or_else(|| ElementError::NoSuchContent { element: "General Chapel Information".to_string(), content: "No data provided".to_string() })?;
+        let general_information = GeneralChapelInformation::from_body(self.body())?
+            .pop()
+            .ok_or_else(|| {
+                Into::<RusaintError>::into(
+                    Into::<WebDynproError>::into(ElementError::NoSuchContent {
+                        element: "General Chapel Information".to_string(),
+                        content: "No data provided".to_string(),
+                    }),
+                )
+            })?;
         let attendances = ChapelAttendance::from_body(self.body())?;
         let absence_requests = ChapelAbsenceRequest::from_body(self.body())?;
-        Ok(
-            ChapelInformation::new(year, semester, general_information, attendances, absence_requests)
-        )
+        Ok(ChapelInformation::new(
+            year,
+            semester,
+            general_information,
+            attendances,
+            absence_requests,
+        ))
     }
-
 }
 
 /// [`Chapel`] 애플리케이션에 사용되는 데이터

--- a/src/application/chapel/mod.rs
+++ b/src/application/chapel/mod.rs
@@ -79,6 +79,7 @@ impl<'a> Chapel {
         Ok(())
     }
 
+    // TODO: 정보가 없을 때 올바른 오류 반환
     /// 해당 학기의 채플 정보를 가져옵니다.
     pub async fn information(&mut self, year: u32, semester: SemesterType) -> Result<ChapelInformation, WebDynproError> {
         self.select_semester(&year.to_string(), semester).await?;

--- a/src/application/chapel/model.rs
+++ b/src/application/chapel/model.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Deserializer};
+
+use crate::{define_elements, model::SemesterType, webdynpro::{client::body::Body, element::complex::SapTable, error::WebDynproError}};
+
+#[derive(Clone, Debug)]
+pub struct ChapelInformation {
+    year: u32,
+    semester: SemesterType,
+    general_information: GeneralChapelInformation,
+    attendances: Vec<ChapelAttendance>,
+    absence_requests: Vec<ChapelAbsenceRequest>,
+}
+
+impl ChapelInformation {
+    pub fn new(year: u32, semester: SemesterType, general_information: GeneralChapelInformation, attendances: Vec<ChapelAttendance>, absence_requests: Vec<ChapelAbsenceRequest>) -> Self {
+        Self { year, semester, general_information, attendances, absence_requests }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GeneralChapelInformation {
+    #[serde(rename(deserialize = "분반"))]
+    division: u32,
+    #[serde(rename(deserialize = "시간표"))]
+    chapel_time: String,
+    #[serde(rename(deserialize = "강의실"))]
+    chapel_room: String,
+    #[serde(rename(deserialize = "층수"))]
+    floor_level: u32,
+    #[serde(rename(deserialize = "좌석번호"))]
+    seat_number: String,
+    #[serde(rename(deserialize = "결석일수"))]
+    absence_time: u32,
+    #[serde(rename(deserialize = "성적"))]
+    result: String,
+    #[serde(rename(deserialize = "비고"))]
+    note: String,
+}
+
+impl<'a> GeneralChapelInformation {
+
+    define_elements! {
+        TABLE: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE";
+    }
+
+    pub fn from_body(body: &'a Body) -> Result<Self, WebDynproError> {
+        todo!()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ChapelAttendance {
+    #[serde(rename(deserialize = "분반"))]
+    division: u32,
+    #[serde(rename(deserialize = "수업일자"))]
+    class_date: String,
+    #[serde(rename(deserialize = "강의구분"))]
+    category: String,
+    #[serde(rename(deserialize = "강사"))]
+    instructor: String,
+    #[serde(rename(deserialize = "소속"))]
+    instructor_department: String,
+    #[serde(rename(deserialize = "제목"))]
+    title: String,
+    #[serde(rename(deserialize = "출결상태"))]
+    attendance: String,
+    #[serde(rename(deserialize = "평가"))]
+    result: String,
+    #[serde(rename(deserialize = "비고"))]
+    note: String,
+}
+
+impl<'a> ChapelAttendance {
+
+    define_elements! {
+        TABLE_A: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE_A";
+    }
+
+    pub fn from_body(body: &'a Body) -> Result<Self, WebDynproError> {
+        todo!()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ChapelAbsenceRequest {
+    #[serde(rename(deserialize = "학년도"))]
+    year: u32,
+    #[serde(rename(deserialize = "학기"), deserialize_with = "deserialize_semester_type")]
+    semester: SemesterType,
+    #[serde(rename(deserialize = "결석구분상세"))]
+    absence_detail: String,
+    #[serde(rename(deserialize = "결석시작일자"))]
+    absence_start: String,
+    #[serde(rename(deserialize = "결석종료일자"))]
+    absence_end: String,
+    #[serde(rename(deserialize = "결석사유(국문)"))]
+    absence_reason_kr: String,
+    #[serde(rename(deserialize = "결석사유(영문)"))]
+    absence_reason_en: String,
+    #[serde(rename(deserialize = "신청일자"))]
+    application_date: String,
+    #[serde(rename(deserialize = "승인일자"))]
+    approval_date: String,
+    #[serde(rename(deserialize = "거부사유"))]
+    denial_reason: String,
+    #[serde(rename(deserialize = "상태"))]
+    status: String
+}
+
+pub fn deserialize_semester_type<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<SemesterType, D::Error> {
+    let value = String::deserialize(deserializer)?;
+    match value.trim() {
+        "1 학기" => Ok(SemesterType::One),
+        "여름 학기" => Ok(SemesterType::Summer),
+        "2 학기" => Ok(SemesterType::Two),
+        "겨울 학기" => Ok(SemesterType::Winter),
+        _ => Err(serde::de::Error::custom("Unknown SemesterType varient"))
+    }
+}
+
+impl<'a> ChapelAbsenceRequest {
+
+    define_elements! {
+        TABLE02_CP_CP: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE02_CP_CP";
+    }
+    pub fn from_body(body: &'a Body) -> Result<Self, WebDynproError> {
+        todo!()
+    }
+}

--- a/src/application/chapel/model.rs
+++ b/src/application/chapel/model.rs
@@ -10,12 +10,10 @@ use crate::{
     model::SemesterType,
     utils::de_with::deserialize_u32_string,
     webdynpro::{
-        client::body::Body,
-        element::{
+        client::body::Body, command::element::complex::ReadSapTableBodyCommand, element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
-        },
-        error::{ElementError, WebDynproError},
+        }, error::{ElementError, WebDynproError}
     },
 };
 
@@ -108,8 +106,7 @@ impl<'a> GeneralChapelInformation {
     }
 
     pub(crate) fn from_body(body: &'a Body) -> Result<Vec<Self>, WebDynproError> {
-        let table_element = Self::TABLE.from_body(body)?;
-        let table = table_element.table()?;
+        let table = body.read(ReadSapTableBodyCommand::new(Self::TABLE))?;
         table.try_table_into::<Self>(body)
     }
 
@@ -203,8 +200,7 @@ impl<'a> ChapelAttendance {
     }
 
     pub(crate) fn from_body(body: &'a Body) -> Result<Vec<Self>, WebDynproError> {
-        let table_element = Self::TABLE_A.from_body(body)?;
-        let table = table_element.table()?;
+        let table = body.read(ReadSapTableBodyCommand::new(Self::TABLE_A))?;
         table.try_table_into::<Self>(body)
     }
 
@@ -322,8 +318,7 @@ impl<'a> ChapelAbsenceRequest {
         TABLE02_CP_CP: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE02_CP_CP";
     }
     pub(crate) fn from_body(body: &'a Body) -> Result<Vec<Self>, WebDynproError> {
-        let table_element = Self::TABLE02_CP_CP.from_body(body)?;
-        let table = table_element.table()?;
+        let table = body.read(ReadSapTableBodyCommand::new(Self::TABLE02_CP_CP))?;
         table.try_table_into::<Self>(body)
     }
 

--- a/src/application/chapel/model.rs
+++ b/src/application/chapel/model.rs
@@ -1,8 +1,11 @@
-use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
 
-use crate::{define_elements, model::SemesterType, webdynpro::{client::body::Body, element::complex::SapTable, error::WebDynproError}};
+use serde::{de::{value::MapDeserializer, IntoDeserializer}, Deserialize, Deserializer};
+
+use crate::{define_elements, model::SemesterType, utils::de_with::deserialize_u32_string, webdynpro::{client::body::Body, element::{complex::{sap_table::FromSapTable, SapTable}, definition::ElementDefinition}, error::{ElementError, WebDynproError}}};
 
 #[derive(Clone, Debug)]
+/// 학기별 채플 정보
 pub struct ChapelInformation {
     year: u32,
     semester: SemesterType,
@@ -12,24 +15,50 @@ pub struct ChapelInformation {
 }
 
 impl ChapelInformation {
-    pub fn new(year: u32, semester: SemesterType, general_information: GeneralChapelInformation, attendances: Vec<ChapelAttendance>, absence_requests: Vec<ChapelAbsenceRequest>) -> Self {
+    pub(crate) fn new(year: u32, semester: SemesterType, general_information: GeneralChapelInformation, attendances: Vec<ChapelAttendance>, absence_requests: Vec<ChapelAbsenceRequest>) -> Self {
         Self { year, semester, general_information, attendances, absence_requests }
+    }
+    
+    /// 해당 채플 정보의 학년도를 반환합니다.
+    pub fn year(&self) -> u32 {
+        self.year
+    }
+    
+    /// 해당 채플 정보의 학기를 반환합니다.
+    pub fn semester(&self) -> SemesterType {
+        self.semester
+    }
+    
+    /// 기본 채플 정보(좌석번호, 결석현황, 성적결과)를 반환합니다.
+    pub fn general_information(&self) -> &GeneralChapelInformation {
+        &self.general_information
+    }
+    
+    /// 채플 출결 정보를 반환합니다.
+    pub fn attendances(&self) -> &[ChapelAttendance] {
+        &self.attendances
+    }
+    
+    /// 채플 결석신청 정보를 반환합니다.
+    pub fn absence_requests(&self) -> &[ChapelAbsenceRequest] {
+        &self.absence_requests
     }
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// 채플 기본 정보(좌석번호, 결석현황, 성적결과)
 pub struct GeneralChapelInformation {
-    #[serde(rename(deserialize = "분반"))]
+    #[serde(rename(deserialize = "분반"), deserialize_with = "deserialize_u32_string")]
     division: u32,
     #[serde(rename(deserialize = "시간표"))]
     chapel_time: String,
     #[serde(rename(deserialize = "강의실"))]
     chapel_room: String,
-    #[serde(rename(deserialize = "층수"))]
+    #[serde(rename(deserialize = "층수"), deserialize_with = "deserialize_u32_string")]
     floor_level: u32,
     #[serde(rename(deserialize = "좌석번호"))]
     seat_number: String,
-    #[serde(rename(deserialize = "결석일수"))]
+    #[serde(rename(deserialize = "결석일수"), deserialize_with = "deserialize_u32_string")]
     absence_time: u32,
     #[serde(rename(deserialize = "성적"))]
     result: String,
@@ -43,14 +72,74 @@ impl<'a> GeneralChapelInformation {
         TABLE: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE";
     }
 
-    pub fn from_body(body: &'a Body) -> Result<Self, WebDynproError> {
-        todo!()
+    pub(crate) fn from_body(body: &'a Body) -> Result<Vec<Self>, WebDynproError> {
+        let table_element = Self::TABLE.from_body(body)?;
+        let table = table_element.table()?;
+        table.try_table_into::<Self>(body)
+    }
+    
+    /// 분반 번호를 반환합니다.
+    pub fn division(&self) -> u32 {
+        self.division
+    }
+    
+    /// 채플 시간을 반환합니다.
+    pub fn chapel_time(&self) -> &str {
+        &self.chapel_time
+    }
+    
+    /// 채플 강의실을 반환합니다.
+    pub fn chapel_room(&self) -> &str {
+        &self.chapel_room
+    }
+
+    /// 층수를 반환합니다.
+    pub fn floor_level(&self) -> u32 {
+        self.floor_level
+    }
+    
+    /// 좌석번호를 반환합니다.
+    pub fn seat_number(&self) -> &str {
+        &self.seat_number
+    }
+    
+    /// 결석일수를 반환합니다.
+    pub fn absence_time(&self) -> u32 {
+        self.absence_time
+    }
+    
+    /// 성적을 반환합니다.
+    pub fn result(&self) -> &str {
+        &self.result
+    }
+    
+    /// 비고 내용을 반환합니다.
+    pub fn note(&self) -> &str {
+        &self.note
+    }
+}
+
+impl<'body> FromSapTable<'body> for GeneralChapelInformation {
+    fn from_table(
+        body: &'body crate::webdynpro::client::body::Body,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+    ) -> Result<Self, WebDynproError> {
+        let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
+        let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();
+        Ok(
+            Self::deserialize(map_de).map_err(|e| ElementError::InvalidContent {
+                element: row.table_def().id().to_string(),
+                content: e.to_string(),
+            })?,
+        )
     }
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// 채플 수업별 출석정보
 pub struct ChapelAttendance {
-    #[serde(rename(deserialize = "분반"))]
+    #[serde(rename(deserialize = "분반"), deserialize_with = "deserialize_u32_string")]
     division: u32,
     #[serde(rename(deserialize = "수업일자"))]
     class_date: String,
@@ -76,14 +165,79 @@ impl<'a> ChapelAttendance {
         TABLE_A: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE_A";
     }
 
-    pub fn from_body(body: &'a Body) -> Result<Self, WebDynproError> {
-        todo!()
+    pub(crate) fn from_body(body: &'a Body) -> Result<Vec<Self>, WebDynproError> {
+        let table_element = Self::TABLE_A.from_body(body)?;
+        let table = table_element.table()?;
+        table.try_table_into::<Self>(body)
+    }
+    
+    /// 채플 분반 번호를 반환합니다.
+    pub fn division(&self) -> u32 {
+        self.division
+    }
+    
+    /// 수업일자를 반환합니다.
+    pub fn class_date(&self) -> &str {
+        &self.class_date
+    }
+    
+    /// 강의구분을 반환합니다.
+    pub fn category(&self) -> &str {
+        &self.category
+    }
+    
+    /// 강사명을 반환합니다.
+    pub fn instructor(&self) -> &str {
+        &self.instructor
+    }
+    
+    /// 강사의 소속을 반환합니다.
+    pub fn instructor_department(&self) -> &str {
+        &self.instructor_department
+    }
+
+    /// 강의 제목을 반환합니다.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+    
+    /// 출결상태를 반환합니다.
+    pub fn attendance(&self) -> &str {
+        &self.attendance
+    }
+    
+    /// 평가 내용을 반환합니다.
+    pub fn result(&self) -> &str {
+        &self.result
+    }
+    
+    /// 비고를 반환합니다.
+    pub fn note(&self) -> &str {
+        &self.note
+    }
+}
+
+impl<'body> FromSapTable<'body> for ChapelAttendance {
+    fn from_table(
+        body: &'body crate::webdynpro::client::body::Body,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+    ) -> Result<Self, WebDynproError> {
+        let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
+        let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();
+        Ok(
+            Self::deserialize(map_de).map_err(|e| ElementError::InvalidContent {
+                element: row.table_def().id().to_string(),
+                content: e.to_string(),
+            })?,
+        )
     }
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// 채플 결석신청 정보
 pub struct ChapelAbsenceRequest {
-    #[serde(rename(deserialize = "학년도"))]
+    #[serde(rename(deserialize = "학년도"), deserialize_with = "deserialize_u32_string")]
     year: u32,
     #[serde(rename(deserialize = "학기"), deserialize_with = "deserialize_semester_type")]
     semester: SemesterType,
@@ -107,7 +261,7 @@ pub struct ChapelAbsenceRequest {
     status: String
 }
 
-pub fn deserialize_semester_type<'de, D: Deserializer<'de>>(
+fn deserialize_semester_type<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<SemesterType, D::Error> {
     let value = String::deserialize(deserializer)?;
@@ -125,7 +279,81 @@ impl<'a> ChapelAbsenceRequest {
     define_elements! {
         TABLE02_CP_CP: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE02_CP_CP";
     }
-    pub fn from_body(body: &'a Body) -> Result<Self, WebDynproError> {
-        todo!()
+    pub(crate) fn from_body(body: &'a Body) -> Result<Vec<Self>, WebDynproError> {
+        let table_element = Self::TABLE02_CP_CP.from_body(body)?;
+        let table = table_element.table()?;
+        table.try_table_into::<Self>(body)
+    }
+    
+    /// 신청 학년도를 반환합니다.
+    pub fn year(&self) -> u32 {
+        self.year
+    }
+    
+    /// 신청 학기를 반환합니다.
+    pub fn semester(&self) -> SemesterType {
+        self.semester
+    }
+    
+    /// 결석구분상세를 반환합니다.
+    pub fn absence_detail(&self) -> &str {
+        &self.absence_detail
+    }
+    
+    /// 결석시작일자를 반환합니다.
+    pub fn absence_start(&self) -> &str {
+        &self.absence_start
+    }
+    
+    /// 결석종료일자를 반환합니다.
+    pub fn absence_end(&self) -> &str {
+        &self.absence_end
+    }
+    
+    /// 국문 결석사유를 반환합니다.
+    pub fn absence_reason_kr(&self) -> &str {
+        &self.absence_reason_kr
+    }
+    
+    /// 영문 결석사유를 반환합니다.
+    pub fn absence_reason_en(&self) -> &str {
+        &self.absence_reason_en
+    }
+    
+    /// 신청일자를 반환합니다.
+    pub fn application_date(&self) -> &str {
+        &self.application_date
+    }
+    
+    /// 승인일자를 반환합니다.
+    pub fn approval_date(&self) -> &str {
+        &self.approval_date
+    }
+    
+    /// 거부사유를 반환합니다.
+    pub fn denial_reason(&self) -> &str {
+        &self.denial_reason
+    }
+    
+    /// 요청 상태를 반환합니다.
+    pub fn status(&self) -> &str {
+        &self.status
+    }
+}
+
+impl<'body> FromSapTable<'body> for ChapelAbsenceRequest {
+    fn from_table(
+        body: &'body crate::webdynpro::client::body::Body,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+    ) -> Result<Self, WebDynproError> {
+        let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
+        let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();
+        Ok(
+            Self::deserialize(map_de).map_err(|e| ElementError::InvalidContent {
+                element: row.table_def().id().to_string(),
+                content: e.to_string(),
+            })?,
+        )
     }
 }

--- a/src/application/chapel/model.rs
+++ b/src/application/chapel/model.rs
@@ -1,8 +1,23 @@
 use std::collections::HashMap;
 
-use serde::{de::{value::MapDeserializer, IntoDeserializer}, Deserialize, Deserializer};
+use serde::{
+    de::{value::MapDeserializer, IntoDeserializer},
+    Deserialize, Deserializer,
+};
 
-use crate::{define_elements, model::SemesterType, utils::de_with::deserialize_u32_string, webdynpro::{client::body::Body, element::{complex::{sap_table::FromSapTable, SapTable}, definition::ElementDefinition}, error::{ElementError, WebDynproError}}};
+use crate::{
+    define_elements,
+    model::SemesterType,
+    utils::de_with::deserialize_u32_string,
+    webdynpro::{
+        client::body::Body,
+        element::{
+            complex::{sap_table::FromSapTable, SapTable},
+            definition::ElementDefinition,
+        },
+        error::{ElementError, WebDynproError},
+    },
+};
 
 #[derive(Clone, Debug)]
 /// 학기별 채플 정보
@@ -15,30 +30,42 @@ pub struct ChapelInformation {
 }
 
 impl ChapelInformation {
-    pub(crate) fn new(year: u32, semester: SemesterType, general_information: GeneralChapelInformation, attendances: Vec<ChapelAttendance>, absence_requests: Vec<ChapelAbsenceRequest>) -> Self {
-        Self { year, semester, general_information, attendances, absence_requests }
+    pub(crate) fn new(
+        year: u32,
+        semester: SemesterType,
+        general_information: GeneralChapelInformation,
+        attendances: Vec<ChapelAttendance>,
+        absence_requests: Vec<ChapelAbsenceRequest>,
+    ) -> Self {
+        Self {
+            year,
+            semester,
+            general_information,
+            attendances,
+            absence_requests,
+        }
     }
-    
+
     /// 해당 채플 정보의 학년도를 반환합니다.
     pub fn year(&self) -> u32 {
         self.year
     }
-    
+
     /// 해당 채플 정보의 학기를 반환합니다.
     pub fn semester(&self) -> SemesterType {
         self.semester
     }
-    
+
     /// 기본 채플 정보(좌석번호, 결석현황, 성적결과)를 반환합니다.
     pub fn general_information(&self) -> &GeneralChapelInformation {
         &self.general_information
     }
-    
+
     /// 채플 출결 정보를 반환합니다.
     pub fn attendances(&self) -> &[ChapelAttendance] {
         &self.attendances
     }
-    
+
     /// 채플 결석신청 정보를 반환합니다.
     pub fn absence_requests(&self) -> &[ChapelAbsenceRequest] {
         &self.absence_requests
@@ -48,17 +75,26 @@ impl ChapelInformation {
 #[derive(Clone, Debug, Deserialize)]
 /// 채플 기본 정보(좌석번호, 결석현황, 성적결과)
 pub struct GeneralChapelInformation {
-    #[serde(rename(deserialize = "분반"), deserialize_with = "deserialize_u32_string")]
+    #[serde(
+        rename(deserialize = "분반"),
+        deserialize_with = "deserialize_u32_string"
+    )]
     division: u32,
     #[serde(rename(deserialize = "시간표"))]
     chapel_time: String,
     #[serde(rename(deserialize = "강의실"))]
     chapel_room: String,
-    #[serde(rename(deserialize = "층수"), deserialize_with = "deserialize_u32_string")]
+    #[serde(
+        rename(deserialize = "층수"),
+        deserialize_with = "deserialize_u32_string"
+    )]
     floor_level: u32,
     #[serde(rename(deserialize = "좌석번호"))]
     seat_number: String,
-    #[serde(rename(deserialize = "결석일수"), deserialize_with = "deserialize_u32_string")]
+    #[serde(
+        rename(deserialize = "결석일수"),
+        deserialize_with = "deserialize_u32_string"
+    )]
     absence_time: u32,
     #[serde(rename(deserialize = "성적"))]
     result: String,
@@ -67,7 +103,6 @@ pub struct GeneralChapelInformation {
 }
 
 impl<'a> GeneralChapelInformation {
-
     define_elements! {
         TABLE: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE";
     }
@@ -77,17 +112,17 @@ impl<'a> GeneralChapelInformation {
         let table = table_element.table()?;
         table.try_table_into::<Self>(body)
     }
-    
+
     /// 분반 번호를 반환합니다.
     pub fn division(&self) -> u32 {
         self.division
     }
-    
+
     /// 채플 시간을 반환합니다.
     pub fn chapel_time(&self) -> &str {
         &self.chapel_time
     }
-    
+
     /// 채플 강의실을 반환합니다.
     pub fn chapel_room(&self) -> &str {
         &self.chapel_room
@@ -97,22 +132,22 @@ impl<'a> GeneralChapelInformation {
     pub fn floor_level(&self) -> u32 {
         self.floor_level
     }
-    
+
     /// 좌석번호를 반환합니다.
     pub fn seat_number(&self) -> &str {
         &self.seat_number
     }
-    
+
     /// 결석일수를 반환합니다.
     pub fn absence_time(&self) -> u32 {
         self.absence_time
     }
-    
+
     /// 성적을 반환합니다.
     pub fn result(&self) -> &str {
         &self.result
     }
-    
+
     /// 비고 내용을 반환합니다.
     pub fn note(&self) -> &str {
         &self.note
@@ -122,8 +157,8 @@ impl<'a> GeneralChapelInformation {
 impl<'body> FromSapTable<'body> for GeneralChapelInformation {
     fn from_table(
         body: &'body crate::webdynpro::client::body::Body,
-        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
-        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();
@@ -139,7 +174,10 @@ impl<'body> FromSapTable<'body> for GeneralChapelInformation {
 #[derive(Clone, Debug, Deserialize)]
 /// 채플 수업별 출석정보
 pub struct ChapelAttendance {
-    #[serde(rename(deserialize = "분반"), deserialize_with = "deserialize_u32_string")]
+    #[serde(
+        rename(deserialize = "분반"),
+        deserialize_with = "deserialize_u32_string"
+    )]
     division: u32,
     #[serde(rename(deserialize = "수업일자"))]
     class_date: String,
@@ -160,7 +198,6 @@ pub struct ChapelAttendance {
 }
 
 impl<'a> ChapelAttendance {
-
     define_elements! {
         TABLE_A: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE_A";
     }
@@ -170,27 +207,27 @@ impl<'a> ChapelAttendance {
         let table = table_element.table()?;
         table.try_table_into::<Self>(body)
     }
-    
+
     /// 채플 분반 번호를 반환합니다.
     pub fn division(&self) -> u32 {
         self.division
     }
-    
+
     /// 수업일자를 반환합니다.
     pub fn class_date(&self) -> &str {
         &self.class_date
     }
-    
+
     /// 강의구분을 반환합니다.
     pub fn category(&self) -> &str {
         &self.category
     }
-    
+
     /// 강사명을 반환합니다.
     pub fn instructor(&self) -> &str {
         &self.instructor
     }
-    
+
     /// 강사의 소속을 반환합니다.
     pub fn instructor_department(&self) -> &str {
         &self.instructor_department
@@ -200,17 +237,17 @@ impl<'a> ChapelAttendance {
     pub fn title(&self) -> &str {
         &self.title
     }
-    
+
     /// 출결상태를 반환합니다.
     pub fn attendance(&self) -> &str {
         &self.attendance
     }
-    
+
     /// 평가 내용을 반환합니다.
     pub fn result(&self) -> &str {
         &self.result
     }
-    
+
     /// 비고를 반환합니다.
     pub fn note(&self) -> &str {
         &self.note
@@ -220,8 +257,8 @@ impl<'a> ChapelAttendance {
 impl<'body> FromSapTable<'body> for ChapelAttendance {
     fn from_table(
         body: &'body crate::webdynpro::client::body::Body,
-        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
-        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();
@@ -237,9 +274,15 @@ impl<'body> FromSapTable<'body> for ChapelAttendance {
 #[derive(Clone, Debug, Deserialize)]
 /// 채플 결석신청 정보
 pub struct ChapelAbsenceRequest {
-    #[serde(rename(deserialize = "학년도"), deserialize_with = "deserialize_u32_string")]
+    #[serde(
+        rename(deserialize = "학년도"),
+        deserialize_with = "deserialize_u32_string"
+    )]
     year: u32,
-    #[serde(rename(deserialize = "학기"), deserialize_with = "deserialize_semester_type")]
+    #[serde(
+        rename(deserialize = "학기"),
+        deserialize_with = "deserialize_semester_type"
+    )]
     semester: SemesterType,
     #[serde(rename(deserialize = "결석구분상세"))]
     absence_detail: String,
@@ -258,7 +301,7 @@ pub struct ChapelAbsenceRequest {
     #[serde(rename(deserialize = "거부사유"))]
     denial_reason: String,
     #[serde(rename(deserialize = "상태"))]
-    status: String
+    status: String,
 }
 
 fn deserialize_semester_type<'de, D: Deserializer<'de>>(
@@ -270,12 +313,11 @@ fn deserialize_semester_type<'de, D: Deserializer<'de>>(
         "여름 학기" => Ok(SemesterType::Summer),
         "2 학기" => Ok(SemesterType::Two),
         "겨울 학기" => Ok(SemesterType::Winter),
-        _ => Err(serde::de::Error::custom("Unknown SemesterType varient"))
+        _ => Err(serde::de::Error::custom("Unknown SemesterType varient")),
     }
 }
 
 impl<'a> ChapelAbsenceRequest {
-
     define_elements! {
         TABLE02_CP_CP: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE02_CP_CP";
     }
@@ -284,57 +326,57 @@ impl<'a> ChapelAbsenceRequest {
         let table = table_element.table()?;
         table.try_table_into::<Self>(body)
     }
-    
+
     /// 신청 학년도를 반환합니다.
     pub fn year(&self) -> u32 {
         self.year
     }
-    
+
     /// 신청 학기를 반환합니다.
     pub fn semester(&self) -> SemesterType {
         self.semester
     }
-    
+
     /// 결석구분상세를 반환합니다.
     pub fn absence_detail(&self) -> &str {
         &self.absence_detail
     }
-    
+
     /// 결석시작일자를 반환합니다.
     pub fn absence_start(&self) -> &str {
         &self.absence_start
     }
-    
+
     /// 결석종료일자를 반환합니다.
     pub fn absence_end(&self) -> &str {
         &self.absence_end
     }
-    
+
     /// 국문 결석사유를 반환합니다.
     pub fn absence_reason_kr(&self) -> &str {
         &self.absence_reason_kr
     }
-    
+
     /// 영문 결석사유를 반환합니다.
     pub fn absence_reason_en(&self) -> &str {
         &self.absence_reason_en
     }
-    
+
     /// 신청일자를 반환합니다.
     pub fn application_date(&self) -> &str {
         &self.application_date
     }
-    
+
     /// 승인일자를 반환합니다.
     pub fn approval_date(&self) -> &str {
         &self.approval_date
     }
-    
+
     /// 거부사유를 반환합니다.
     pub fn denial_reason(&self) -> &str {
         &self.denial_reason
     }
-    
+
     /// 요청 상태를 반환합니다.
     pub fn status(&self) -> &str {
         &self.status
@@ -344,8 +386,8 @@ impl<'a> ChapelAbsenceRequest {
 impl<'body> FromSapTable<'body> for ChapelAbsenceRequest {
     fn from_table(
         body: &'body crate::webdynpro::client::body::Body,
-        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
-        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/application/course_grades/model.rs
+++ b/src/application/course_grades/model.rs
@@ -160,8 +160,8 @@ impl SemesterGrade {
 impl<'body> FromSapTable<'body> for SemesterGrade {
     fn from_table(
         body: &'body crate::webdynpro::client::body::Body,
-        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
-        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/application/course_schedule/model.rs
+++ b/src/application/course_schedule/model.rs
@@ -637,8 +637,8 @@ pub struct Lecture {
 impl<'body> FromSapTable<'body> for Lecture {
     fn from_table(
         body: &'body crate::webdynpro::client::body::Body,
-        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
-        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/application/graduation_requirements/model.rs
+++ b/src/application/graduation_requirements/model.rs
@@ -271,8 +271,8 @@ fn deserialize_lectures<'de, D: Deserializer<'de>>(
 impl<'body> FromSapTable<'body> for GraduationRequirement {
     fn from_table(
         body: &'body crate::webdynpro::client::body::Body,
-        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader<'body>,
-        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow<'body>,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, crate::webdynpro::error::WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -160,3 +160,6 @@ pub mod graduation_requirements;
 
 /// 학생 정보 조회: [`StudentInformation`](student_information::StudentInformation)
 pub mod student_information;
+
+/// 채플 정보 조회: [`Chapel`](chapel::Chapel)
+pub mod chapel;

--- a/src/application/student_information/model/academic_record.rs
+++ b/src/application/student_information/model/academic_record.rs
@@ -101,8 +101,8 @@ impl StudentAcademicRecord {
 impl<'a> FromSapTable<'a> for StudentAcademicRecord {
     fn from_table(
         body: &'a crate::webdynpro::client::body::Body,
-        header: &'a crate::webdynpro::element::complex::sap_table::SapTableHeader<'a>,
-        row: &'a crate::webdynpro::element::complex::sap_table::SapTableRow<'a>,
+        header: &'a crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'a crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, crate::webdynpro::error::WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
             let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/application/student_information/model/family.rs
+++ b/src/application/student_information/model/family.rs
@@ -155,8 +155,8 @@ impl StudentFamilyMember {
 impl<'a> FromSapTable<'a> for StudentFamilyMember {
     fn from_table(
         body: &'a crate::webdynpro::client::body::Body,
-        header: &'a crate::webdynpro::element::complex::sap_table::SapTableHeader<'a>,
-        row: &'a crate::webdynpro::element::complex::sap_table::SapTableRow<'a>,
+        header: &'a crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'a crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
         let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/application/student_information/model/transfer.rs
+++ b/src/application/student_information/model/transfer.rs
@@ -94,8 +94,8 @@ impl StudentTransferRecord {
 impl<'a> FromSapTable<'a> for StudentTransferRecord {
     fn from_table(
         body: &'a crate::webdynpro::client::body::Body,
-        header: &'a crate::webdynpro::element::complex::sap_table::SapTableHeader<'a>,
-        row: &'a crate::webdynpro::element::complex::sap_table::SapTableRow<'a>,
+        header: &'a crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'a crate::webdynpro::element::complex::sap_table::SapTableRow,
     ) -> Result<Self, crate::webdynpro::error::WebDynproError> {
         let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
             let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -14,6 +14,9 @@ pub enum RusaintError {
     /// 숭실대학교 SSO 로그인 오류
     #[error("Failed to login with ssu sso: {0}")]
     SsoLoginError(#[from] SsuSsoError),
+    /// 각 애플리케이션에서 반환하는 오류
+    #[error("Error from application: {0}")]
+    ApplicationError(#[from] ApplicationError)
 }
 
 /// 숭실대학교 SSO 로그인 실패 시 반환하는 오류
@@ -28,4 +31,11 @@ pub enum SsuSsoError {
     /// 페이지 로그인이 실패하여 토큰이 응답에 포함되지 않음
     #[error("Token is not included in response: {0}")]
     CantFindToken(String),
+}
+
+/// 특정 애플리케이션에서 반환하는 오류
+#[derive(Error, Debug)]
+pub enum ApplicationError {
+    #[error("No chapel information provided")]
+    NoChapelInformation
 }

--- a/src/utils/de_with.rs
+++ b/src/utils/de_with.rs
@@ -4,14 +4,14 @@ pub(crate) fn deserialize_u32_string<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<u32, D::Error> {
     let value = String::deserialize(deserializer)?;
-    value.parse().map_err(serde::de::Error::custom)
+    value.trim().parse().map_err(serde::de::Error::custom)
 }
 
 pub(crate) fn deserialize_f32_string<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<f32, D::Error> {
     let value = String::deserialize(deserializer)?;
-    value.parse().map_err(serde::de::Error::custom)
+    value.trim().parse().map_err(serde::de::Error::custom)
 }
 
 pub(crate) fn deserialize_with_trim<'de, D: Deserializer<'de>>(

--- a/src/webdynpro/client/body/mod.rs
+++ b/src/webdynpro/client/body/mod.rs
@@ -5,7 +5,7 @@ use lol_html::{element, html_content::ContentType, rewrite_str, RewriteStrSettin
 use roxmltree::Node;
 use scraper::{Html, Selector};
 
-use crate::webdynpro::error::{BodyError, UpdateBodyError};
+use crate::webdynpro::{command::WebDynproReadCommand, error::{BodyError, UpdateBodyError, WebDynproError}};
 
 use super::SapSsrClient;
 
@@ -158,6 +158,11 @@ impl Body {
     /// 도큐먼트 파싱을 위한 `scraper::Html` 구조체를 반환합니다.
     pub fn document(&self) -> &Html {
         &self.document
+    }
+
+    /// WebDynpro 바디에 읽기 명령을 전송합니다.
+    pub fn read<T: WebDynproReadCommand>(&self, command: T) -> Result<T::Result, WebDynproError> {
+        command.read(self)
     }
 
     pub(crate) fn ssr_client(&self) -> &SapSsrClient {

--- a/src/webdynpro/client/mod.rs
+++ b/src/webdynpro/client/mod.rs
@@ -12,7 +12,7 @@ use reqwest::{cookie::Jar, header::*, RequestBuilder};
 use std::sync::Arc;
 use url::Url;
 
-use super::{command::WebDynproCommand, element::definition::ElementDefinition};
+use super::{command::{WebDynproCommand, WebDynproReadCommand}, element::definition::ElementDefinition};
 
 /// WebDynpro 애플리케이션의 웹 요청 및 페이지 문서 처리를 담당하는 클라이언트
 pub struct WebDynproClient {
@@ -109,6 +109,11 @@ impl<'a> WebDynproClient {
         command: T,
     ) -> Result<T::Result, WebDynproError> {
         command.dispatch(self).await
+    }
+
+    /// WebDynpro 클라이언트에 읽기 명령을 전송합니다.
+    pub fn read<T: WebDynproReadCommand>(&self, command: T) -> Result<T::Result, WebDynproError> {
+        command.read(self.body())
     }
 
     #[allow(dead_code)]

--- a/src/webdynpro/command/element/complex.rs
+++ b/src/webdynpro/command/element/complex.rs
@@ -1,4 +1,4 @@
-use crate::webdynpro::{command::WebDynproCommand, element::{complex::{sap_table::SapTableBody, SapTableDef}, definition::ElementDefinition}, error::WebDynproError};
+use crate::webdynpro::{command::{WebDynproCommand, WebDynproReadCommand}, element::{complex::{sap_table::SapTableBody, SapTableDef}, definition::ElementDefinition}, error::WebDynproError};
 
 /// [`SapTableBody`]를 반환
 pub struct ReadSapTableBodyCommand {
@@ -12,6 +12,13 @@ impl ReadSapTableBodyCommand {
     }
 }
 
+impl WebDynproReadCommand for ReadSapTableBodyCommand {
+    fn read(&self, body: &crate::webdynpro::client::body::Body) -> Result<Self::Result, WebDynproError> {
+        let body = self.element_def.from_body(body)?.table()?.clone();
+        Ok(body)
+    }
+}
+
 impl WebDynproCommand for ReadSapTableBodyCommand {
     type Result = SapTableBody;
 
@@ -19,7 +26,6 @@ impl WebDynproCommand for ReadSapTableBodyCommand {
         &self,
         client: &mut crate::webdynpro::client::WebDynproClient,
     ) -> Result<Self::Result, WebDynproError> {
-        let body = self.element_def.from_body(client.body())?.table()?.clone();
-        Ok(body)
+        self.read(client.body())
     }
 }

--- a/src/webdynpro/command/element/complex.rs
+++ b/src/webdynpro/command/element/complex.rs
@@ -1,0 +1,25 @@
+use crate::webdynpro::{command::WebDynproCommand, element::{complex::{sap_table::SapTableBody, SapTableDef}, definition::ElementDefinition}, error::WebDynproError};
+
+/// [`SapTableBody`]를 반환
+pub struct ReadSapTableBodyCommand {
+    element_def: SapTableDef,
+}
+
+impl ReadSapTableBodyCommand {
+    /// 새로운 명령 객체를 생성합니다.
+    pub fn new(element_def: SapTableDef) -> ReadSapTableBodyCommand {
+        Self { element_def }
+    }
+}
+
+impl WebDynproCommand for ReadSapTableBodyCommand {
+    type Result = SapTableBody;
+
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        let body = self.element_def.from_body(client.body())?.table()?.clone();
+        Ok(body)
+    }
+}

--- a/src/webdynpro/command/element/mod.rs
+++ b/src/webdynpro/command/element/mod.rs
@@ -1,6 +1,9 @@
 /// 액션 분류의 엘리먼트([`Button`](crate::webdynpro::element::action::Button), [`Link`](crate::webdynpro::element::action::Link))를 위한 명령
 pub mod action;
 
+/// complex 분류의 엘리먼트([`SapTable`](crate::webdynpro::element::complex::SapTable))를 위한 명령
+pub mod complex;
+
 /// 선택 분류의 엘리먼트([`ListBox`](crate::webdynpro::element::selection::list_box::ListBox), [`ComboBox`](crate::webdynpro::element::selection::ComboBox))를 위한 명령
 pub mod selection;
 

--- a/src/webdynpro/command/element/selection.rs
+++ b/src/webdynpro/command/element/selection.rs
@@ -1,6 +1,6 @@
 use crate::webdynpro::{
     client::EventProcessResult,
-    command::WebDynproCommand,
+    command::{WebDynproCommand, WebDynproReadCommand},
     element::{
         definition::ElementDefinition,
         selection::{
@@ -156,6 +156,13 @@ impl ReadComboBoxLSDataCommand {
     }
 }
 
+impl WebDynproReadCommand for ReadComboBoxLSDataCommand {
+    fn read(&self, body: &crate::webdynpro::client::body::Body) -> Result<Self::Result, WebDynproError> {
+        let lsdata = self.element_def.from_body(body)?.lsdata().clone();
+        Ok(lsdata)
+    }
+}
+
 impl WebDynproCommand for ReadComboBoxLSDataCommand {
     type Result = ComboBoxLSData;
 
@@ -163,8 +170,7 @@ impl WebDynproCommand for ReadComboBoxLSDataCommand {
         &self,
         client: &mut crate::webdynpro::client::WebDynproClient,
     ) -> Result<Self::Result, WebDynproError> {
-        let lsdata = self.element_def.from_body(client.body())?.lsdata().clone();
-        Ok(lsdata)
+        self.read(client.body())
     }
 }
 
@@ -180,6 +186,16 @@ impl ReadComboBoxItemListBoxCommand {
     }
 }
 
+impl WebDynproReadCommand for ReadComboBoxItemListBoxCommand {
+    fn read(&self, body: &crate::webdynpro::client::body::Body) -> Result<Self::Result, WebDynproError> {
+        let listbox_def = self
+            .element_def
+            .from_body(body)?
+            .item_list_box(body)?;
+        Ok(listbox_def)
+    }
+}
+
 impl WebDynproCommand for ReadComboBoxItemListBoxCommand {
     type Result = ListBoxDefWrapper;
 
@@ -187,11 +203,7 @@ impl WebDynproCommand for ReadComboBoxItemListBoxCommand {
         &self,
         client: &mut crate::webdynpro::client::WebDynproClient,
     ) -> Result<Self::Result, WebDynproError> {
-        let listbox_def = self
-            .element_def
-            .from_body(client.body())?
-            .item_list_box(client.body())?;
-        Ok(listbox_def)
+        self.read(client.body())
     }
 }
 
@@ -207,14 +219,9 @@ impl ReadListBoxItemInfoCommand {
     }
 }
 
-impl WebDynproCommand for ReadListBoxItemInfoCommand {
-    type Result = Vec<ListBoxItemInfo>;
-
-    async fn dispatch(
-        &self,
-        client: &mut crate::webdynpro::client::WebDynproClient,
-    ) -> Result<Self::Result, WebDynproError> {
-        let element = self.element_def.from_body(client.body())?;
+impl WebDynproReadCommand for ReadListBoxItemInfoCommand {
+    fn read(&self, body: &crate::webdynpro::client::body::Body) -> Result<Self::Result, WebDynproError> {
+        let element = self.element_def.from_body(body)?;
         match element {
             ListBoxWrapper::ListBoxPopup(list_box) => Ok(list_box
                 .list_box()
@@ -241,5 +248,16 @@ impl WebDynproCommand for ReadListBoxItemInfoCommand {
                 .item_infos()?
                 .collect::<Vec<ListBoxItemInfo>>()),
         }
+    }
+}
+
+impl WebDynproCommand for ReadListBoxItemInfoCommand {
+    type Result = Vec<ListBoxItemInfo>;
+
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        self.read(client.body())
     }
 }

--- a/src/webdynpro/command/mod.rs
+++ b/src/webdynpro/command/mod.rs
@@ -1,4 +1,4 @@
-use super::{client::WebDynproClient, error::WebDynproError};
+use super::{client::{body::Body, WebDynproClient}, error::WebDynproError};
 
 /// WebDynpro 클라이언트를 조작하는 명령
 pub trait WebDynproCommand {
@@ -7,6 +7,13 @@ pub trait WebDynproCommand {
 
     /// 해당 명령을 주어진 클라이언트에 대해 실행합니다.
     async fn dispatch(&self, client: &mut WebDynproClient) -> Result<Self::Result, WebDynproError>;
+}
+
+/// WebDynpro 클라이언트 내부 페이지에서 데이터를 가져오는 명령
+pub trait WebDynproReadCommand: WebDynproCommand {
+
+    /// 해당 명령을 주어진 클라이언트에 대해 실행합니다.
+    fn read(&self, body: &Body) -> Result<Self::Result, WebDynproError>;
 }
 
 /// 엘리먼트 관련 명령

--- a/src/webdynpro/element/complex/sap_table/body.rs
+++ b/src/webdynpro/element/complex/sap_table/body.rs
@@ -14,21 +14,19 @@ use super::{
 };
 
 /// [`SapTable`](super::SapTable) 내부 테이블
-#[derive(Clone, custom_debug_derive::Debug)]
+#[derive(Clone, Debug)]
 #[allow(unused)]
-pub struct SapTableBody<'a> {
+pub struct SapTableBody {
     table_def: SapTableDef,
-    #[debug(skip)]
-    elem_ref: ElementRef<'a>,
-    header: SapTableHeader<'a>,
-    rows: Vec<SapTableRow<'a>>,
+    header: SapTableHeader,
+    rows: Vec<SapTableRow>,
 }
 
-impl<'a> SapTableBody<'a> {
+impl<'a> SapTableBody {
     pub(super) fn new(
         table_def: SapTableDef,
         elem_ref: ElementRef<'a>,
-    ) -> Result<SapTableBody<'a>, ElementError> {
+    ) -> Result<SapTableBody, ElementError> {
         let ref_iter = elem_ref
             .children()
             .filter_map(|node| scraper::ElementRef::wrap(node));
@@ -47,7 +45,7 @@ impl<'a> SapTableBody<'a> {
                 content: "Multiple header in table".to_owned(),
             });
         }
-        let mut rows: Vec<SapTableRow<'a>> = Vec::new();
+        let mut rows: Vec<SapTableRow> = Vec::new();
         // Def, rowsize, colsize
         type CellSpanInfo = (SapTableCellDefWrapper, u32, u32);
         let mut spans: HashMap<u32, CellSpanInfo> = HashMap::new();
@@ -118,7 +116,6 @@ impl<'a> SapTableBody<'a> {
         }
         Ok(SapTableBody {
             table_def,
-            elem_ref,
             header,
             rows,
         })
@@ -147,7 +144,7 @@ impl<'a> SapTableBody<'a> {
     }
 
     /// 헤더 행을 반환합니다.
-    pub fn header(&self) -> &SapTableHeader<'a> {
+    pub fn header(&self) -> &SapTableHeader {
         &self.header
     }
 
@@ -162,8 +159,8 @@ impl<'a> SapTableBody<'a> {
     }
 }
 
-impl<'a> Index<usize> for SapTableBody<'a> {
-    type Output = SapTableRow<'a>;
+impl<'a> Index<usize> for SapTableBody {
+    type Output = SapTableRow;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.rows[index]

--- a/src/webdynpro/element/complex/sap_table/body.rs
+++ b/src/webdynpro/element/complex/sap_table/body.rs
@@ -55,8 +55,14 @@ impl<'a> SapTableBody {
                 .attr("rt")
                 .and_then(|s| Some(s.into()))
                 .unwrap_or(SapTableRowType::default());
+            let row_count = row_ref.value().attr("rr").and_then(|s| s.parse::<u32>().ok());
             if matches!(row_type, SapTableRowType::Header) {
                 continue;
+            }
+
+            // If it meets empty row(zero-index), instantly terminate repetition
+            if row_count.is_some_and(|c| c == 0) {
+                break;
             }
             let subct_selector = scraper::Selector::parse("[subct]").unwrap();
             let subcts = row_ref.select(&subct_selector);

--- a/src/webdynpro/element/complex/sap_table/from_sap_table.rs
+++ b/src/webdynpro/element/complex/sap_table/from_sap_table.rs
@@ -13,16 +13,16 @@ pub trait FromSapTable<'body>: Sized {
     /// [`SapTableRow`]를 해당 형으로 변환하고자 시도하는 함수
     fn from_table(
         body: &'body Body,
-        header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError>;
 }
 
 impl<'body> FromSapTable<'body> for Vec<Option<String>> {
     fn from_table(
         body: &'body Body,
-        _header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        _header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let iter = row.iter_value(body);
         let vec = iter
@@ -51,8 +51,8 @@ impl<'body> FromSapTable<'body> for Vec<Option<String>> {
 impl<'body> FromSapTable<'body> for Vec<String> {
     fn from_table(
         body: &'body Body,
-        _header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        _header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let iter = row.iter_value(body);
         iter.map(|val| match val {
@@ -78,8 +78,8 @@ impl<'body> FromSapTable<'body> for Vec<String> {
 impl<'body> FromSapTable<'body> for Vec<(String, Option<String>)> {
     fn from_table(
         body: &'body Body,
-        header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let header_iter = header.iter_value(body);
         let header_string = header_iter
@@ -114,8 +114,8 @@ impl<'body> FromSapTable<'body> for Vec<(String, Option<String>)> {
 impl<'body> FromSapTable<'body> for Vec<(String, String)> {
     fn from_table(
         body: &'body Body,
-        header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let header_iter = header.iter_value(body);
         let header_string = header_iter
@@ -151,8 +151,8 @@ impl<'body> FromSapTable<'body> for Vec<(String, String)> {
 impl<'body> FromSapTable<'body> for HashMap<String, String> {
     fn from_table(
         body: &'body Body,
-        header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let vec = row.try_row_into::<Vec<(String, String)>>(header, body)?;
         Ok(vec.into_iter().collect())
@@ -162,8 +162,8 @@ impl<'body> FromSapTable<'body> for HashMap<String, String> {
 impl<'body> FromSapTable<'body> for HashMap<String, Option<String>> {
     fn from_table(
         body: &'body Body,
-        header: &'body SapTableHeader<'body>,
-        row: &'body SapTableRow<'body>,
+        header: &'body SapTableHeader,
+        row: &'body SapTableRow,
     ) -> Result<Self, WebDynproError> {
         let vec = row.try_row_into::<Vec<(String, Option<String>)>>(header, body)?;
         Ok(vec.into_iter().collect())

--- a/src/webdynpro/element/complex/sap_table/header.rs
+++ b/src/webdynpro/element/complex/sap_table/header.rs
@@ -15,12 +15,10 @@ use super::{
 };
 
 /// [`SapTable`](super::SapTable)의 행
-#[derive(Clone, custom_debug_derive::Debug)]
+#[derive(Clone, Debug)]
 #[allow(unused)]
-pub struct SapTableHeader<'a> {
+pub struct SapTableHeader {
     table_def: SapTableDef,
-    #[debug(skip)]
-    elem_ref: ElementRef<'a>,
     cells: Vec<SapTableCellDefWrapper>,
     row_index: Option<u32>,
     user_data: Option<String>,
@@ -30,11 +28,11 @@ pub struct SapTableHeader<'a> {
     selection_state: SapTableSelectionState,
 }
 
-impl<'a> SapTableHeader<'a> {
+impl<'a> SapTableHeader {
     pub(super) fn new(
         table_def: SapTableDef,
         header_ref: ElementRef<'a>,
-    ) -> Result<SapTableHeader<'a>, ElementError> {
+    ) -> Result<SapTableHeader, ElementError> {
         let row = header_ref.value();
         let subct_selector = scraper::Selector::parse("[subct]").unwrap();
         let subcts = header_ref.select(&subct_selector);
@@ -55,7 +53,6 @@ impl<'a> SapTableHeader<'a> {
         }
         Ok(SapTableHeader {
             table_def,
-            elem_ref: header_ref,
             cells,
             row_index: row.attr("rr").and_then(|s| s.parse::<u32>().ok()),
             user_data: row.attr("uDat").and_then(|s| Some(s.to_owned())),
@@ -162,7 +159,7 @@ impl<'a> SapTableHeader<'a> {
     }
 }
 
-impl<'a> Index<usize> for SapTableHeader<'a> {
+impl<'a> Index<usize> for SapTableHeader {
     type Output = SapTableCellDefWrapper;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -13,7 +13,7 @@ use self::property::AccessType;
 define_element_interactable! {
     #[doc = "테이블"]
     SapTable<"ST", "SapTable"> {
-        table: OnceCell<Option<SapTableBody<'a>>>,
+        table: OnceCell<Option<SapTableBody>>,
     },
     #[doc = "[`SapTable`]의 정의"]
     SapTableDef,
@@ -39,7 +39,7 @@ impl<'a> SapTable<'a> {
     }
 
     /// 테이블 내부 컨텐츠를 반환합니다.
-    pub fn table(&self) -> Result<&SapTableBody<'a>, WebDynproError> {
+    pub fn table(&self) -> Result<&SapTableBody, WebDynproError> {
         self.table
             .get_or_init(|| self.parse_table().ok())
             .as_ref()
@@ -49,7 +49,7 @@ impl<'a> SapTable<'a> {
             }))
     }
 
-    fn parse_table(&self) -> Result<SapTableBody<'a>, WebDynproError> {
+    fn parse_table(&self) -> Result<SapTableBody, WebDynproError> {
         let def: SapTableDef = {
             if let Cow::Borrowed(id) = self.id {
                 SapTableDef::new(id)

--- a/src/webdynpro/element/complex/sap_table/row.rs
+++ b/src/webdynpro/element/complex/sap_table/row.rs
@@ -14,12 +14,10 @@ use super::{
 };
 
 /// [`SapTable`](super::SapTable)의 행
-#[derive(Clone, custom_debug_derive::Debug)]
+#[derive(Clone, Debug)]
 #[allow(unused)]
-pub struct SapTableRow<'a> {
+pub struct SapTableRow {
     table_def: SapTableDef,
-    #[debug(skip)]
-    elem_ref: ElementRef<'a>,
     cells: Vec<SapTableCellDefWrapper>,
     row_index: Option<u32>,
     user_data: Option<String>,
@@ -30,16 +28,15 @@ pub struct SapTableRow<'a> {
     row_type: SapTableRowType,
 }
 
-impl<'a> SapTableRow<'a> {
+impl<'a> SapTableRow {
     pub(super) fn new(
         table_def: SapTableDef,
         row_ref: ElementRef<'a>,
         cells: Vec<SapTableCellDefWrapper>,
-    ) -> Result<SapTableRow<'a>, ElementError> {
+    ) -> Result<SapTableRow, ElementError> {
         let row = row_ref.value();
         Ok(SapTableRow {
             table_def,
-            elem_ref: row_ref,
             cells,
             row_index: row.attr("rr").and_then(|s| s.parse::<u32>().ok()),
             user_data: row.attr("uDat").and_then(|s| Some(s.to_owned())),
@@ -119,14 +116,14 @@ impl<'a> SapTableRow<'a> {
     /// 행을 [`FromSapTable`]을 구현하는 형으로 변환합니다.
     pub fn try_row_into<T: FromSapTable<'a>>(
         &'a self,
-        header: &'a SapTableHeader<'a>,
+        header: &'a SapTableHeader,
         body: &'a Body,
     ) -> Result<T, WebDynproError> {
         T::from_table(body, header, self)
     }
 }
 
-impl<'a> Index<usize> for SapTableRow<'a> {
+impl<'a> Index<usize> for SapTableRow {
     type Output = SapTableCellDefWrapper;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/tests/application/chapel.rs
+++ b/tests/application/chapel.rs
@@ -1,0 +1,17 @@
+use rusaint::{application::{chapel::Chapel, USaintClientBuilder}, model::SemesterType};
+use serial_test::serial;
+
+use crate::get_session;
+
+#[tokio::test]
+#[serial]
+async fn chapel() {
+    let session = get_session().await.unwrap();
+    let mut app = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<Chapel>()
+        .await
+        .unwrap();
+    let info = app.information(2022, SemesterType::Two).await.unwrap();
+    println!("{:?}", info);
+}

--- a/tests/application/mod.rs
+++ b/tests/application/mod.rs
@@ -1,4 +1,5 @@
 mod course_grades;
 mod course_schedule;
+mod chapel;
 mod graduation_requirements;
 mod student_information;


### PR DESCRIPTION
# What's in this pull request
- `Chapel`(채플정보조회) 애플리케이션을 구현했습니다.
- `deserialize_f32_string`과 `deserialize_u32_string` 함수에서 trim 을 미리 수행하도록 하였습니다.
- 채플 정보가 없을 경우 `ApplicationError::NoChapelInformation` 을 반환합니다.
- 테이블 상의 빈 row를 읽어들이지 않도록 수정했습니다.
- 웹 요청을 수행하지 않는 명령을 위한 `WebDynproReadCommand` 트레이트를 추가했습니다.
- 기존 `Read~` 접두사를 가진 명령어가 `WebDynproReadCommand`를 구현하도록 했습니다.
- `SapTableBody`, `SapTableRow`와 `SapTableHeader`에 `ElementRef`를 제거하여 `'body` 라이프타임 의존성을 제거했습니다.
- `ReadSapTableBodyCommand` 명령을 추가했습니다.