### PR TITLE
[feat] `PersonalCourseSchedule`, `LectureAssessment` 애플리케이션

### DIFF
--- a/src/application/chapel/mod.rs
+++ b/src/application/chapel/mod.rs
@@ -82,7 +82,6 @@ impl<'a> Chapel {
         Ok(())
     }
 
-    // TODO: 정보가 없을 때 올바른 오류 반환
     /// 해당 학기의 채플 정보를 가져옵니다.
     pub async fn information(
         &mut self,

--- a/src/application/chapel/model.rs
+++ b/src/application/chapel/model.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 use serde::{
     de::{value::MapDeserializer, IntoDeserializer},
-    Deserialize, Deserializer,
+    Deserialize,
 };
 
 use crate::{
     define_elements,
     error::ApplicationError,
     model::SemesterType,
-    utils::de_with::deserialize_u32_string,
+    utils::de_with::{deserialize_semester_type, deserialize_u32_string},
     webdynpro::{
         client::body::Body,
         command::element::complex::ReadSapTableBodyCommand,
@@ -334,19 +334,6 @@ pub struct ChapelAbsenceRequest {
     denial_reason: String,
     #[serde(rename(deserialize = "상태"))]
     status: String,
-}
-
-fn deserialize_semester_type<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<SemesterType, D::Error> {
-    let value = String::deserialize(deserializer)?;
-    match value.trim() {
-        "1 학기" => Ok(SemesterType::One),
-        "여름 학기" => Ok(SemesterType::Summer),
-        "2 학기" => Ok(SemesterType::Two),
-        "겨울 학기" => Ok(SemesterType::Winter),
-        _ => Err(serde::de::Error::custom("Unknown SemesterType varient")),
-    }
 }
 
 impl<'a> ChapelAbsenceRequest {

--- a/src/application/lecture_assessment/mod.rs
+++ b/src/application/lecture_assessment/mod.rs
@@ -1,0 +1,182 @@
+use model::LectureAssessmentResult;
+
+use crate::{
+    define_elements,
+    model::SemesterType,
+    webdynpro::{
+        client::body::Body,
+        command::element::{
+            action::ButtonPressCommand,
+            complex::{
+                ReadSapTableBodyCommand, ReadSapTableLSDataCommand, SapTableVerticalScrollCommand,
+            },
+            selection::{ComboBoxChangeCommand, ComboBoxSelectCommand, ReadComboBoxLSDataCommand},
+        },
+        element::{
+            action::Button, complex::SapTable, definition::ElementDefinition, selection::ComboBox,
+        },
+        error::{ElementError, WebDynproError},
+    },
+    RusaintError,
+};
+
+use super::{USaintApplication, USaintClient};
+
+/// [강의평가조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMB2W1010)
+pub struct LectureAssessment {
+    client: USaintClient,
+}
+
+impl USaintApplication for LectureAssessment {
+    const APP_NAME: &'static str = "ZCMB2W1010";
+
+    fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(Self { client })
+        }
+    }
+}
+
+impl<'a> LectureAssessment {
+    define_elements! {
+        DDLB_01: ComboBox<'a> = "ZCMB2W1010.ID_0001:MAIN.DDLB_01";
+        DDLB_02: ComboBox<'a> = "ZCMB2W1010.ID_0001:MAIN.DDLB_02";
+        IF_01: ComboBox<'a> = "ZCMB2W1010.ID_0001:MAIN.IF_01";
+        ILSM_OBJID: ComboBox<'a> = "WDR_SELECT_OPTIONS.ID_15B7446540DB284588CCE6BAC0049040:SELECTION_SCREEN.ILSM_OBJID";
+        IF_04: ComboBox<'a> = "ZCMB2W1010.ID_0001:MAIN.IF_04";
+        BT_SEARCH: Button<'a> = "ZCMB2W1010.ID_0001:MAIN.BT_SEARCH";
+        TABLE: SapTable<'a> = "ZCMB2W1010.ID_0001:MAIN.TABLE";
+    }
+
+    fn semester_to_key(period: SemesterType) -> &'static str {
+        match period {
+            SemesterType::One => "090",
+            SemesterType::Summer => "091",
+            SemesterType::Two => "092",
+            SemesterType::Winter => "0923",
+        }
+    }
+
+    fn body(&self) -> &Body {
+        self.client.body()
+    }
+
+    async fn search(
+        &mut self,
+        year: &str,
+        semester: SemesterType,
+        lecture_name: Option<&str>,
+        lecture_code: Option<u32>,
+        professor_name: Option<&str>,
+    ) -> Result<(), WebDynproError> {
+        let semester = Self::semester_to_key(semester);
+        let year_combobox_lsdata = self
+            .client
+            .read(ReadComboBoxLSDataCommand::new(Self::DDLB_01))?;
+        let semester_combobox_lsdata = self
+            .client
+            .read(ReadComboBoxLSDataCommand::new(Self::DDLB_02))?;
+        if (|| Some(year_combobox_lsdata.key()?.as_str()))() != Some(year) {
+            self.client
+                .send(ComboBoxSelectCommand::new(Self::DDLB_01, &year, false))
+                .await?;
+        }
+        if (|| Some(semester_combobox_lsdata.key()?.as_str()))() != Some(semester) {
+            self.client
+                .send(ComboBoxSelectCommand::new(Self::DDLB_02, semester, false))
+                .await?;
+        }
+        if let Some(lecture_name) = lecture_name {
+            self.client
+                .send(ComboBoxChangeCommand::new(Self::IF_01, lecture_name, false))
+                .await?;
+        }
+        if let Some(lecture_code) = lecture_code {
+            self.client
+                .send(ComboBoxChangeCommand::new(
+                    Self::ILSM_OBJID,
+                    &lecture_code.to_string(),
+                    false,
+                ))
+                .await?;
+        }
+        if let Some(professor_name) = professor_name {
+            self.client
+                .send(ComboBoxChangeCommand::new(
+                    Self::IF_04,
+                    professor_name,
+                    false,
+                ))
+                .await?;
+        }
+        self.client
+            .send(ButtonPressCommand::new(Self::BT_SEARCH))
+            .await?;
+        Ok(())
+    }
+
+    /// 검색 조건에 맞는 강의평가 정보를 가져옵니다.
+    pub async fn find_assessments(
+        &mut self,
+        year: u32,
+        semester: SemesterType,
+        lecture_name: Option<&str>,
+        lecture_code: Option<u32>,
+        professor_name: Option<&str>,
+    ) -> Result<Vec<LectureAssessmentResult>, RusaintError> {
+        self.search(
+            &year.to_string(),
+            semester,
+            lecture_name,
+            lecture_code,
+            professor_name,
+        )
+        .await?;
+        let row_count = self
+            .body()
+            .read(ReadSapTableLSDataCommand::new(Self::TABLE))?
+            .row_count()
+            .map(|u| u.to_owned())
+            .ok_or_else(|| {
+                WebDynproError::Element(ElementError::NoSuchData {
+                    element: Self::TABLE.id().to_string(),
+                    field: "row_count".to_string(),
+                })
+            })?
+            .try_into()
+            .unwrap();
+        let mut results: Vec<LectureAssessmentResult> = Vec::with_capacity(row_count);
+        while results.len() < row_count {
+            let table = self
+                .body()
+                .read(ReadSapTableBodyCommand::new(Self::TABLE))?;
+            let mut partial_results =
+                table.try_table_into::<LectureAssessmentResult>(self.body())?;
+            if results.len() + partial_results.len() > row_count {
+                let overflowed = results.len() + partial_results.len() - row_count;
+                partial_results.drain(0..overflowed);
+            }
+            results.append(&mut partial_results);
+            if results.len() < row_count {
+                self.client
+                    .send(SapTableVerticalScrollCommand::new(
+                        Self::TABLE,
+                        results.len().try_into().unwrap(),
+                        "",
+                        "SCROLLBAR",
+                        false,
+                        false,
+                        false,
+                        false,
+                    ))
+                    .await?;
+            }
+        }
+        Ok(results)
+    }
+}
+
+/// [`LectureAssessment`] 애플리케이션에 사용되는 데이터
+pub mod model;

--- a/src/application/lecture_assessment/model.rs
+++ b/src/application/lecture_assessment/model.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+use serde::{
+    de::{value::MapDeserializer, IntoDeserializer},
+    Deserialize,
+};
+
+use crate::{
+    model::SemesterType,
+    utils::de_with::{deserialize_f32_string, deserialize_semester_type, deserialize_u32_string},
+    webdynpro::{
+        element::{complex::sap_table::FromSapTable, definition::ElementDefinition},
+        error::{ElementError, WebDynproError},
+    },
+};
+
+/// 강의평가 결과
+#[derive(Clone, Debug, Deserialize)]
+pub struct LectureAssessmentResult {
+    #[serde(rename(deserialize = "년도"))]
+    year: String,
+    #[serde(
+        rename(deserialize = "학기"),
+        deserialize_with = "deserialize_semester_type"
+    )]
+    semester: SemesterType,
+    #[serde(
+        rename(deserialize = "과목코드"),
+        deserialize_with = "deserialize_u32_string"
+    )]
+    lecture_code: u32,
+    #[serde(rename(deserialize = "과목명"))]
+    lecture_name: String,
+    #[serde(
+        rename(deserialize = "학점"),
+        deserialize_with = "deserialize_f32_string"
+    )]
+    points: f32,
+    #[serde(rename(deserialize = "교수명"))]
+    professor: String,
+    #[serde(rename(deserialize = "소속대학"))]
+    collage: String,
+    #[serde(rename(deserialize = "소속학과"))]
+    department: String,
+    #[serde(rename(deserialize = "직위명"))]
+    position: String,
+    #[serde(
+        rename(deserialize = "점수"),
+        deserialize_with = "deserialize_f32_string"
+    )]
+    score: f32,
+}
+
+impl LectureAssessmentResult {
+    /// 강의 학년도를 반환합니다.
+    pub fn year(&self) -> &str {
+        &self.year
+    }
+
+    /// 강의 학기를 반환합니다.
+    pub fn semester(&self) -> SemesterType {
+        self.semester
+    }
+
+    /// 과목 코드를 반환합니다.
+    pub fn lecture_code(&self) -> u32 {
+        self.lecture_code
+    }
+
+    /// 과목명을 반환합니다.
+    pub fn lecture_name(&self) -> &str {
+        &self.lecture_name
+    }
+
+    /// 강의의 학점을 반환합니다.
+    pub fn points(&self) -> f32 {
+        self.points
+    }
+
+    /// 강의 담당 교수명을 반환합니다.
+    pub fn professor(&self) -> &str {
+        &self.professor
+    }
+
+    /// 교수(강사)의 단과대학을 반환합니다.
+    pub fn collage(&self) -> &str {
+        &self.collage
+    }
+
+    /// 교수(강사)의 학과(부)를 반환합니다.
+    pub fn department(&self) -> &str {
+        &self.department
+    }
+
+    /// 교수(강사)의 직책을 반환합니다.
+    pub fn position(&self) -> &str {
+        &self.position
+    }
+
+    /// 강의평가 점수를 반환합니다.
+    pub fn score(&self) -> f32 {
+        self.score
+    }
+}
+
+impl<'body> FromSapTable<'body> for LectureAssessmentResult {
+    fn from_table(
+        body: &'body crate::webdynpro::client::body::Body,
+        header: &'body crate::webdynpro::element::complex::sap_table::SapTableHeader,
+        row: &'body crate::webdynpro::element::complex::sap_table::SapTableRow,
+    ) -> Result<Self, WebDynproError> {
+        let map_string = row.try_row_into::<HashMap<String, String>>(header, body)?;
+        let map_de: MapDeserializer<_, serde::de::value::Error> = map_string.into_deserializer();
+        Ok(
+            Self::deserialize(map_de).map_err(|e| ElementError::InvalidContent {
+                element: row.table_def().id().to_string(),
+                content: e.to_string(),
+            })?,
+        )
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -171,3 +171,6 @@ pub mod chapel;
 
 /// 개인 수업 시간표 조회: [`PersonalCourseSchedule`](personal_course_schedule::PersonalCourseSchedule)
 pub mod personal_course_schedule;
+
+/// 강의평가 조회: [`LectureAssessment`](lecture_assessment::LectureAssessment)
+pub mod lecture_assessment;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -168,3 +168,6 @@ pub mod student_information;
 
 /// 채플 정보 조회: [`Chapel`](chapel::Chapel)
 pub mod chapel;
+
+/// 개인 수업 시간표 조회: [`PersonalCourseSchedule`](personal_course_schedule::PersonalCourseSchedule)
+pub mod personal_course_schedule;

--- a/src/application/personal_course_schedule/mod.rs
+++ b/src/application/personal_course_schedule/mod.rs
@@ -1,0 +1,116 @@
+use model::PersonalCourseScheduleInformation;
+
+use crate::{
+    define_elements,
+    error::ApplicationError,
+    model::SemesterType,
+    webdynpro::{
+        client::body::Body,
+        command::element::selection::{ComboBoxSelectCommand, ReadComboBoxLSDataCommand},
+        element::{complex::SapTable, definition::ElementDefinition, selection::ComboBox},
+        error::{ElementError, WebDynproError},
+    },
+    RusaintError,
+};
+
+use super::{USaintApplication, USaintClient};
+
+/// [개인수업시간표](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW2102)
+pub struct PersonalCourseSchedule {
+    client: USaintClient,
+}
+
+impl USaintApplication for PersonalCourseSchedule {
+    const APP_NAME: &'static str = "ZCMW2102";
+
+    fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
+        if client.name() != Self::APP_NAME {
+            Err(RusaintError::InvalidClientError)
+        } else {
+            Ok(Self { client })
+        }
+    }
+}
+
+impl<'a> PersonalCourseSchedule {
+    define_elements! {
+        PERYR: ComboBox<'a> = "ZCMW_PERIOD_RE.ID_D8FB9BECD84FD622F5EAED9E0BE35D27:VIW_MAIN.PERYR";
+        PERID: ComboBox<'a> = "ZCMW_PERIOD_RE.ID_D8FB9BECD84FD622F5EAED9E0BE35D27:VIW_MAIN.PERID";
+        TABLE: SapTable<'a> = "ZCMW2102.ID_0001:VIW_MAIN.TABLE";
+    }
+
+    fn semester_to_key(period: SemesterType) -> &'static str {
+        match period {
+            SemesterType::One => "090",
+            SemesterType::Summer => "091",
+            SemesterType::Two => "092",
+            SemesterType::Winter => "0923",
+        }
+    }
+
+    fn body(&self) -> &Body {
+        self.client.body()
+    }
+
+    async fn select_semester(
+        &mut self,
+        year: &str,
+        semester: SemesterType,
+    ) -> Result<(), WebDynproError> {
+        let semester = Self::semester_to_key(semester);
+        let year_combobox_lsdata = self
+            .client
+            .read(ReadComboBoxLSDataCommand::new(Self::PERYR))?;
+        let semester_combobox_lsdata = self
+            .client
+            .read(ReadComboBoxLSDataCommand::new(Self::PERID))?;
+        if (|| Some(year_combobox_lsdata.key()?.as_str()))() != Some(year) {
+            self.client
+                .send(ComboBoxSelectCommand::new(Self::PERYR, &year, false))
+                .await?;
+        }
+        if (|| Some(semester_combobox_lsdata.key()?.as_str()))() != Some(semester) {
+            self.client
+                .send(ComboBoxSelectCommand::new(Self::PERID, semester, false))
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// 해당 학기의 시간표 정보를 가져옵니다.
+    pub async fn schedule(
+        &mut self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<PersonalCourseScheduleInformation, RusaintError> {
+        self.select_semester(&year.to_string(), semester).await?;
+        match Self::TABLE.from_body(self.body()) {
+            Ok(table) => {
+                let table_body = table.table()?;
+                let row_string: Vec<Vec<Option<String>>> =
+                    table_body.try_table_into::<Vec<Option<String>>>(self.body())?;
+                let mut schedule: [[String; 10]; 7] = Default::default();
+                for (row_idx, row) in row_string.into_iter().skip(1).enumerate() {
+                    row.into_iter()
+                        .skip(1)
+                        .enumerate()
+                        .filter_map(|(col_idx, option)| match option {
+                            Some(str) => Some((col_idx, str)),
+                            None => None,
+                        })
+                        .for_each(|(col_idx, str)| schedule[col_idx][row_idx] = str);
+                }
+                Ok(PersonalCourseScheduleInformation::new(schedule))
+            }
+            Err(err) => match err {
+                WebDynproError::Element(ElementError::InvalidId(_id)) => Err(
+                    RusaintError::ApplicationError(ApplicationError::NoScheduleInformation),
+                ),
+                err => Err(RusaintError::WebDynproError(err)),
+            },
+        }
+    }
+}
+
+/// [`PersonalCourseSchedule`] 애플리케이션에 사용되는 데이터
+pub mod model;

--- a/src/application/personal_course_schedule/model.rs
+++ b/src/application/personal_course_schedule/model.rs
@@ -1,0 +1,16 @@
+/// 개인의 수업 시간표 정보를 조회합니다.
+#[derive(Clone, Debug)]
+pub struct PersonalCourseScheduleInformation {
+    schedule: [[String; 10]; 7],
+}
+
+impl PersonalCourseScheduleInformation {
+    pub(super) fn new(schedule: [[String; 10]; 7]) -> Self {
+        Self { schedule }
+    }
+
+    /// 시간표 배열을 반환합니다.
+    pub fn schedule(&self) -> &[[String; 10]; 7] {
+        &self.schedule
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -16,7 +16,7 @@ pub enum RusaintError {
     SsoLoginError(#[from] SsuSsoError),
     /// 각 애플리케이션에서 반환하는 오류
     #[error("Error from application: {0}")]
-    ApplicationError(#[from] ApplicationError)
+    ApplicationError(#[from] ApplicationError),
 }
 
 /// 숭실대학교 SSO 로그인 실패 시 반환하는 오류
@@ -37,5 +37,7 @@ pub enum SsuSsoError {
 #[derive(Error, Debug)]
 pub enum ApplicationError {
     #[error("No chapel information provided")]
-    NoChapelInformation
+    NoChapelInformation,
+    #[error("No schedule information provided")]
+    NoScheduleInformation,
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -45,4 +45,7 @@ pub enum ApplicationError {
     /// 찾고자 하는 강의의 강의평가 정보가 없음
     #[error("No Lecture assessment found")]
     NoLectureAssessments,
+    /// 조건에 맞는 강의를 찾을 수 없음
+    #[error("No lecture found")]
+    NoLectureResult,
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -36,8 +36,10 @@ pub enum SsuSsoError {
 /// 특정 애플리케이션에서 반환하는 오류
 #[derive(Error, Debug)]
 pub enum ApplicationError {
+    /// 학생의 해당 학기 채플 정보가 없음
     #[error("No chapel information provided")]
     NoChapelInformation,
+    /// 학생의 해당 학기 시간표 정보가 없음
     #[error("No schedule information provided")]
     NoScheduleInformation,
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -42,4 +42,7 @@ pub enum ApplicationError {
     /// 학생의 해당 학기 시간표 정보가 없음
     #[error("No schedule information provided")]
     NoScheduleInformation,
+    /// 찾고자 하는 강의의 강의평가 정보가 없음
+    #[error("No Lecture assessment found")]
+    NoLectureAssessments,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub mod application;
 #[cfg(feature = "application")]
 mod error;
 #[cfg(feature = "application")]
+pub use error::ApplicationError;
+#[cfg(feature = "application")]
 pub use error::RusaintError;
 #[cfg(feature = "application")]
 pub use error::SsuSsoError;

--- a/src/utils/de_with.rs
+++ b/src/utils/de_with.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Deserializer};
 
+use crate::model::SemesterType;
+
 pub(crate) fn deserialize_u32_string<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<u32, D::Error> {
@@ -35,7 +37,6 @@ pub(crate) fn deserialize_bool_string<'de, D: Deserializer<'de>>(
     Ok(value.trim() == "true")
 }
 
-
 pub(crate) fn deserialize_optional_string<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Option<String>, D::Error> {
@@ -45,5 +46,18 @@ pub(crate) fn deserialize_optional_string<'de, D: Deserializer<'de>>(
         Ok(None)
     } else {
         Ok(Some(value.to_string()))
+    }
+}
+
+pub(crate) fn deserialize_semester_type<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<SemesterType, D::Error> {
+    let value = String::deserialize(deserializer)?;
+    match value.trim() {
+        "1 학기" => Ok(SemesterType::One),
+        "여름 학기" => Ok(SemesterType::Summer),
+        "2 학기" => Ok(SemesterType::Two),
+        "겨울 학기" => Ok(SemesterType::Winter),
+        _ => Err(serde::de::Error::custom("Unknown SemesterType varient")),
     }
 }

--- a/src/webdynpro/command/element/complex.rs
+++ b/src/webdynpro/command/element/complex.rs
@@ -1,4 +1,105 @@
-use crate::webdynpro::{command::{WebDynproCommand, WebDynproReadCommand}, element::{complex::{sap_table::SapTableBody, SapTableDef}, definition::ElementDefinition}, error::WebDynproError};
+use crate::webdynpro::{
+    client::EventProcessResult,
+    command::{WebDynproCommand, WebDynproReadCommand},
+    element::{
+        complex::{sap_table::SapTableBody, SapTableDef, SapTableLSData},
+        definition::ElementDefinition,
+        Element,
+    },
+    error::WebDynproError,
+};
+
+/// 주어진 [`SapTable`](crate::webdynpro::element::complex::SapTable)의 상하 스크롤을 수행
+pub struct SapTableVerticalScrollCommand {
+    element_def: SapTableDef,
+    first_visible_item_index: u32,
+    cell_id: String,
+    access_type: String,
+    selection_follow_focus: bool,
+    shift: bool,
+    ctrl: bool,
+    alt: bool,
+}
+
+impl SapTableVerticalScrollCommand {
+    /// 새로운 명령 객체를 생성합니다.
+    pub fn new(
+        element_def: SapTableDef,
+        first_visible_item_index: u32,
+        cell_id: &str,
+        access_type: &str,
+        selection_follow_focus: bool,
+        shift: bool,
+        ctrl: bool,
+        alt: bool,
+    ) -> Self {
+        Self {
+            element_def,
+            first_visible_item_index,
+            cell_id: cell_id.to_string(),
+            access_type: access_type.to_string(),
+            selection_follow_focus,
+            shift,
+            ctrl,
+            alt,
+        }
+    }
+}
+
+impl WebDynproCommand for SapTableVerticalScrollCommand {
+    type Result = EventProcessResult;
+
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        let event = (&self.element_def)
+            .from_body(client.body())?
+            .vertical_scroll(
+                self.first_visible_item_index,
+                &self.cell_id,
+                &self.access_type,
+                self.selection_follow_focus,
+                self.shift,
+                self.ctrl,
+                self.alt,
+            )?;
+        client.process_event(false, event).await
+    }
+}
+
+/// [`SapTableLSData`]를 반환
+pub struct ReadSapTableLSDataCommand {
+    element_def: SapTableDef,
+}
+
+impl ReadSapTableLSDataCommand {
+    /// 새로운 명령 객체를 생성합니다.
+    pub fn new(element_def: SapTableDef) -> ReadSapTableLSDataCommand {
+        Self { element_def }
+    }
+}
+
+impl WebDynproReadCommand for ReadSapTableLSDataCommand {
+    fn read(
+        &self,
+        body: &crate::webdynpro::client::body::Body,
+    ) -> Result<Self::Result, WebDynproError> {
+        let lsdata = self.element_def.from_body(body)?.lsdata().clone();
+        Ok(lsdata)
+    }
+}
+
+impl WebDynproCommand for ReadSapTableLSDataCommand {
+    type Result = SapTableLSData;
+
+    async fn dispatch(
+        &self,
+        client: &mut crate::webdynpro::client::WebDynproClient,
+    ) -> Result<Self::Result, WebDynproError> {
+        self.read(client.body())
+    }
+}
 
 /// [`SapTableBody`]를 반환
 pub struct ReadSapTableBodyCommand {
@@ -13,7 +114,10 @@ impl ReadSapTableBodyCommand {
 }
 
 impl WebDynproReadCommand for ReadSapTableBodyCommand {
-    fn read(&self, body: &crate::webdynpro::client::body::Body) -> Result<Self::Result, WebDynproError> {
+    fn read(
+        &self,
+        body: &crate::webdynpro::client::body::Body,
+    ) -> Result<Self::Result, WebDynproError> {
         let body = self.element_def.from_body(body)?.table()?.clone();
         Ok(body)
     }

--- a/src/webdynpro/element/complex/sap_table/mod.rs
+++ b/src/webdynpro/element/complex/sap_table/mod.rs
@@ -121,6 +121,36 @@ impl<'a> SapTable<'a> {
         ]);
         self.fire_event("CellSelect".to_string(), parameters)
     }
+
+    /// 테이블을 상하로 스크롤하는 이벤트를 반환합니다.
+    pub fn vertical_scroll(
+        &self,
+        first_visible_item_index: u32,
+        cell_id: &str,
+        access_type: &str,
+        selection_follow_focus: bool,
+        shift: bool,
+        ctrl: bool,
+        alt: bool,
+    ) -> Result<Event, WebDynproError> {
+        let parameters: HashMap<String, String> = HashMap::from([
+            ("Id".to_string(), self.id.clone().to_string()),
+            (
+                "FirstVisibleItemIndex".to_string(),
+                first_visible_item_index.to_string(),
+            ),
+            ("CellId".to_string(), cell_id.to_owned()),
+            ("AccessType".to_string(), access_type.to_string()),
+            (
+                "SelectionFollowFocus".to_string(),
+                selection_follow_focus.to_string(),
+            ),
+            ("Shift".to_string(), shift.to_string()),
+            ("Ctrl".to_string(), ctrl.to_string()),
+            ("Alt".to_string(), alt.to_string()),
+        ]);
+        self.fire_event("VerticalScroll".to_string(), parameters)
+    }
 }
 
 mod body;

--- a/src/webdynpro/element/text/caption.rs
+++ b/src/webdynpro/element/text/caption.rs
@@ -49,7 +49,12 @@ impl<'a> Caption<'a> {
 
     /// 내부 텍스트를 반환합니다.
     pub fn text(&self) -> &str {
-        self.text
-            .get_or_init(|| self.element_ref().text().collect::<String>())
+        self.text.get_or_init(|| {
+            self.element_ref()
+                .text()
+                .flat_map(|str| ["\n", str])
+                .skip(1)
+                .collect::<String>()
+        })
     }
 }

--- a/src/webdynpro/element/text/caption.rs
+++ b/src/webdynpro/element/text/caption.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, cell::OnceCell};
 
+use scraper::Node;
+
 use crate::webdynpro::element::{define_element_interactable, property::Visibility, Element};
 
 define_element_interactable! {
@@ -51,9 +53,18 @@ impl<'a> Caption<'a> {
     pub fn text(&self) -> &str {
         self.text.get_or_init(|| {
             self.element_ref()
-                .text()
-                .flat_map(|str| ["\n", str])
-                .skip(1)
+                .children()
+                .filter_map(|node| match node.value() {
+                    Node::Text(text) => Some(text.to_string()),
+                    Node::Element(elem) => {
+                        if elem.name() == "br" {
+                            Some("\n".to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                })
                 .collect::<String>()
         })
     }

--- a/src/webdynpro/element/text/text_view.rs
+++ b/src/webdynpro/element/text/text_view.rs
@@ -38,7 +38,12 @@ impl<'a> TextView<'a> {
 
     /// 내부 텍스트를 반환합니다.
     pub fn text(&self) -> &str {
-        self.text
-            .get_or_init(|| self.element_ref().text().collect::<String>())
+        self.text.get_or_init(|| {
+            self.element_ref()
+                .text()
+                .flat_map(|str| ["\n", str])
+                .skip(1)
+                .collect::<String>()
+        })
     }
 }

--- a/src/webdynpro/element/text/text_view.rs
+++ b/src/webdynpro/element/text/text_view.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, cell::OnceCell};
 
+use scraper::Node;
+
 use crate::webdynpro::element::{define_element_interactable, property::Visibility, Element};
 
 define_element_interactable! {
@@ -40,9 +42,18 @@ impl<'a> TextView<'a> {
     pub fn text(&self) -> &str {
         self.text.get_or_init(|| {
             self.element_ref()
-                .text()
-                .flat_map(|str| ["\n", str])
-                .skip(1)
+                .children()
+                .filter_map(|node| match node.value() {
+                    Node::Text(text) => Some(text.to_string()),
+                    Node::Element(elem) => {
+                        if elem.name() == "br" {
+                            Some("\n".to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                })
                 .collect::<String>()
         })
     }

--- a/tests/application/chapel.rs
+++ b/tests/application/chapel.rs
@@ -1,4 +1,8 @@
-use rusaint::{application::{chapel::Chapel, USaintClientBuilder}, model::SemesterType};
+use rusaint::{
+    application::{chapel::Chapel, USaintClientBuilder},
+    model::SemesterType,
+    ApplicationError, RusaintError,
+};
 use serial_test::serial;
 
 use crate::get_session;
@@ -13,5 +17,23 @@ async fn chapel() {
         .await
         .unwrap();
     let info = app.information(2022, SemesterType::Two).await.unwrap();
+    println!("{:?}", info);
+}
+
+#[tokio::test]
+#[serial]
+async fn no_chapel() {
+    let session = get_session().await.unwrap();
+    let mut app = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<Chapel>()
+        .await
+        .unwrap();
+    let info = app.information(2024, SemesterType::Two).await.unwrap_err();
+    assert!(matches!(
+        info,
+        RusaintError::ApplicationError(ApplicationError::NoChapelInformation)
+    ));
+    println!("{:?}", info);
     println!("{:?}", info);
 }

--- a/tests/application/course_schedule.rs
+++ b/tests/application/course_schedule.rs
@@ -4,6 +4,7 @@ use rusaint::{
         USaintClientBuilder,
     },
     model::SemesterType,
+    ApplicationError, RusaintError,
 };
 use serial_test::serial;
 
@@ -27,4 +28,27 @@ async fn find_major() {
         println!("{:?}", lecture);
     }
     assert!(true);
+}
+
+#[tokio::test]
+#[serial]
+async fn find_nothing() {
+    let session = get_session().await.unwrap();
+    let mut app = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<CourseSchedule>()
+        .await
+        .unwrap();
+    let category = LectureCategory::find_by_lecture("내가A+받는강의");
+    let Some(err) = app
+        .find_lectures(2023, SemesterType::Two, category)
+        .await
+        .err()
+    else {
+        panic!("this lecture query should return error");
+    };
+    assert!(matches!(
+        err,
+        RusaintError::ApplicationError(ApplicationError::NoLectureResult)
+    ));
 }

--- a/tests/application/lecture_assessment.rs
+++ b/tests/application/lecture_assessment.rs
@@ -1,0 +1,24 @@
+use rusaint::{
+    application::{lecture_assessment::LectureAssessment, USaintClientBuilder},
+    model::SemesterType,
+};
+use serial_test::serial;
+
+use crate::get_session;
+
+#[tokio::test]
+#[serial]
+async fn lecture_assessment() {
+    let session = get_session().await.unwrap();
+    let mut app = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<LectureAssessment>()
+        .await
+        .unwrap();
+    let info = app
+        .find_assessments(2023, SemesterType::Two, Some("마케팅"), None, None)
+        .await
+        .unwrap();
+    assert!(info.len() == 29);
+    println!("{} results: {:?}", info.len(), info);
+}

--- a/tests/application/mod.rs
+++ b/tests/application/mod.rs
@@ -4,3 +4,4 @@ mod course_schedule;
 mod graduation_requirements;
 mod personal_course_schedule;
 mod student_information;
+mod lecture_assessment;

--- a/tests/application/mod.rs
+++ b/tests/application/mod.rs
@@ -1,5 +1,6 @@
+mod chapel;
 mod course_grades;
 mod course_schedule;
-mod chapel;
 mod graduation_requirements;
+mod personal_course_schedule;
 mod student_information;

--- a/tests/application/personal_course_schedule.rs
+++ b/tests/application/personal_course_schedule.rs
@@ -1,0 +1,20 @@
+use rusaint::{
+    application::{personal_course_schedule::PersonalCourseSchedule, USaintClientBuilder},
+    model::SemesterType,
+};
+use serial_test::serial;
+
+use crate::get_session;
+
+#[tokio::test]
+#[serial]
+async fn schedule() {
+    let session = get_session().await.unwrap();
+    let mut app = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<PersonalCourseSchedule>()
+        .await
+        .unwrap();
+    let info = app.schedule(2022, SemesterType::Two).await.unwrap();
+    println!("{:?}", info);
+}

--- a/tests/application/personal_course_schedule.rs
+++ b/tests/application/personal_course_schedule.rs
@@ -1,6 +1,7 @@
 use rusaint::{
     application::{personal_course_schedule::PersonalCourseSchedule, USaintClientBuilder},
     model::SemesterType,
+    ApplicationError, RusaintError,
 };
 use serial_test::serial;
 
@@ -16,5 +17,22 @@ async fn schedule() {
         .await
         .unwrap();
     let info = app.schedule(2022, SemesterType::Two).await.unwrap();
+    println!("{:?}", info);
+}
+
+#[tokio::test]
+#[serial]
+async fn no_schedule() {
+    let session = get_session().await.unwrap();
+    let mut app = USaintClientBuilder::new()
+        .session(session)
+        .build_into::<PersonalCourseSchedule>()
+        .await
+        .unwrap();
+    let info = app.schedule(2024, SemesterType::Two).await.unwrap_err();
+    assert!(matches!(
+        info,
+        RusaintError::ApplicationError(ApplicationError::NoScheduleInformation)
+    ));
     println!("{:?}", info);
 }


### PR DESCRIPTION
# What's in this pull request
- `PersonalCourseSchedule`(개인수업시간표) 애플리케이션을 구현했습니다.
- `LectureAssessment`(강의평가조회) 애플리케이션을 구현했습니다.
- `ApplicationError`를 pub 선언했습니다.
- `Chapel`, `PersonalCourseSchedule`, `CourseSchedule`에서 정보가 없을 때 올바른 오류를 반환하는지 확인하는 테스트 케이스를 추가했습니다.
- `TextView::text()`와 `Caption::text()`에서 개행이 표시되지 않는 문제를 수정했습니다.
- `SapTableVerticalScrollCommand`를 구현했습니다.