### PR TITLE
[refactor] `impl USaintApplication` 구조체에 `-Application` 접두사 추가

### DIFF
--- a/src/application/chapel/mod.rs
+++ b/src/application/chapel/mod.rs
@@ -18,11 +18,11 @@ use crate::{
 use super::{USaintApplication, USaintClient};
 
 /// [채플정보조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW3681)
-pub struct Chapel {
+pub struct ChapelApplication {
     client: USaintClient,
 }
 
-impl USaintApplication for Chapel {
+impl USaintApplication for ChapelApplication {
     const APP_NAME: &'static str = "ZCMW3681";
 
     fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
@@ -34,7 +34,7 @@ impl USaintApplication for Chapel {
     }
 }
 
-impl<'a> Chapel {
+impl<'a> ChapelApplication {
     define_elements! {
         SEL_PERYR: ComboBox<'a> = "ZCMW3681.ID_0001:V_MAIN.TC_SEL_PERYR";
         SEL_PERID: ComboBox<'a> = "ZCMW3681.ID_0001:V_MAIN.TC_SEL_PERID";

--- a/src/application/chapel/mod.rs
+++ b/src/application/chapel/mod.rs
@@ -111,5 +111,5 @@ impl<'a> ChapelApplication {
     }
 }
 
-/// [`Chapel`] 애플리케이션에 사용되는 데이터
+/// [`ChapelApplication`] 애플리케이션에 사용되는 데이터
 pub mod model;

--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -495,7 +495,7 @@ impl<'a> CourseGradesApplication {
     }
 }
 
-/// [`CourseGrades`]에서 사용하는 데이터
+/// [`CourseGradesApplication`]에서 사용하는 데이터
 pub mod model;
 
 #[cfg(test)]

--- a/src/application/course_grades/mod.rs
+++ b/src/application/course_grades/mod.rs
@@ -30,11 +30,11 @@ use self::model::{ClassGrade, CourseType, GradeSummary, SemesterGrade};
 use super::{USaintApplication, USaintClient};
 
 /// [학생 성적 조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMB3W0017)
-pub struct CourseGrades {
+pub struct CourseGradesApplication {
     client: USaintClient,
 }
 
-impl USaintApplication for CourseGrades {
+impl USaintApplication for CourseGradesApplication {
     const APP_NAME: &'static str = "ZCMB3W0017";
 
     fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
@@ -47,7 +47,7 @@ impl USaintApplication for CourseGrades {
 }
 
 #[allow(unused)]
-impl<'a> CourseGrades {
+impl<'a> CourseGradesApplication {
     // Elements for Grade Summaries
     define_elements!(
         // Grade summaries by semester
@@ -88,7 +88,7 @@ impl<'a> CourseGrades {
     );
 
     async fn close_popups(&mut self) -> Result<(), WebDynproError> {
-        fn make_close_event(app: &CourseGrades) -> Option<Event> {
+        fn make_close_event(app: &CourseGradesApplication) -> Option<Event> {
             let body = app.client.body();
             let popup_selector =
                 scraper::Selector::parse(format!(r#"[ct="{}"]"#, PopupWindow::CONTROL_ID).as_str())
@@ -503,7 +503,7 @@ mod test {
     use serial_test::serial;
 
     use crate::{
-        application::{course_grades::CourseGrades, USaintClientBuilder},
+        application::{course_grades::CourseGradesApplication, USaintClientBuilder},
         global_test_utils::get_session,
         webdynpro::element::{layout::PopupWindow, Element},
     };
@@ -514,7 +514,7 @@ mod test {
         let session = get_session().await.unwrap();
         let mut app = USaintClientBuilder::new()
             .session(session)
-            .build_into::<CourseGrades>()
+            .build_into::<CourseGradesApplication>()
             .await
             .unwrap();
         app.close_popups().await.unwrap();

--- a/src/application/course_schedule/mod.rs
+++ b/src/application/course_schedule/mod.rs
@@ -23,11 +23,11 @@ use crate::{
 use super::{USaintApplication, USaintClient};
 
 /// [강의시간표](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW2100)
-pub struct CourseSchedule {
+pub struct CourseScheduleApplication {
     client: USaintClient,
 }
 
-impl USaintApplication for CourseSchedule {
+impl USaintApplication for CourseScheduleApplication {
     const APP_NAME: &'static str = "ZCMW2100";
 
     fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
@@ -40,7 +40,7 @@ impl USaintApplication for CourseSchedule {
 }
 
 #[allow(unused)]
-impl<'a> CourseSchedule {
+impl<'a> CourseScheduleApplication {
     // 메인 요소
     define_elements! {
         PERIOD_YEAR: ComboBox<'a> = "ZCMW_PERIOD_RE.ID_A61C4ED604A2BFC2A8F6C6038DE6AF18:VIW_MAIN.PERYR";

--- a/src/application/graduation_requirements/model.rs
+++ b/src/application/graduation_requirements/model.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug)]
 /// 졸업 학생 정보
-pub struct GraduationStudentInfo {
+pub struct GraduationStudent {
     number: u32,
     name: String,
     grade: u32,
@@ -30,7 +30,7 @@ pub struct GraduationStudentInfo {
     completed_points: f32,
 }
 
-impl GraduationStudentInfo {
+impl GraduationStudent {
     pub(super) fn new(
         number: u32,
         name: &str,
@@ -124,12 +124,12 @@ impl GraduationStudentInfo {
 
 #[derive(Debug)]
 /// 전체 졸업 요건 정보
-pub struct GraduationRequirementsInfo {
+pub struct GraduationRequirements {
     is_graduatable: bool,
     requirements: HashMap<String, GraduationRequirement>,
 }
 
-impl GraduationRequirementsInfo {
+impl GraduationRequirements {
     pub(super) fn new(
         is_graduatable: bool,
         requirements: HashMap<String, GraduationRequirement>,

--- a/src/application/lecture_assessment/mod.rs
+++ b/src/application/lecture_assessment/mod.rs
@@ -30,11 +30,11 @@ use crate::{
 use super::{USaintApplication, USaintClient};
 
 /// [강의평가조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMB2W1010)
-pub struct LectureAssessment {
+pub struct LectureAssessmentApplication {
     client: USaintClient,
 }
 
-impl USaintApplication for LectureAssessment {
+impl USaintApplication for LectureAssessmentApplication {
     const APP_NAME: &'static str = "ZCMB2W1010";
 
     fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
@@ -46,7 +46,7 @@ impl USaintApplication for LectureAssessment {
     }
 }
 
-impl<'a> LectureAssessment {
+impl<'a> LectureAssessmentApplication {
     define_elements! {
         DDLB_01: ComboBox<'a> = "ZCMB2W1010.ID_0001:MAIN.DDLB_01";
         DDLB_02: ComboBox<'a> = "ZCMB2W1010.ID_0001:MAIN.DDLB_02";

--- a/src/application/lecture_assessment/mod.rs
+++ b/src/application/lecture_assessment/mod.rs
@@ -204,5 +204,5 @@ impl<'a> LectureAssessmentApplication {
     }
 }
 
-/// [`LectureAssessment`] 애플리케이션에 사용되는 데이터
+/// [`LectureAssessmentApplication`] 애플리케이션에 사용되는 데이터
 pub mod model;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -154,23 +154,23 @@ impl USaintClientBuilder {
         T::from_client(client)
     }
 }
-/// 학생 성적 조회: [`CourseGrades`](course_grades::CourseGrades)
+/// 학생 성적 조회: [`CourseGradesApplication`](course_grades::CourseGradesApplication)
 pub mod course_grades;
 
-/// 강의시간표: [`CourseSchedule`](course_schedule::CourseSchedule)
+/// 강의시간표: [`CourseScheduleApplication`](course_schedule::CourseScheduleApplication)
 pub mod course_schedule;
 
-/// 졸업사정표: [`GraduationRequirements`](graduation_requirements::GraduationRequirements)
+/// 졸업사정표: [`GraduationRequirementsApplication`](graduation_requirements::GraduationRequirementsApplication)
 pub mod graduation_requirements;
 
-/// 학생 정보 조회: [`StudentInformation`](student_information::StudentInformation)
+/// 학생 정보 조회: [`StudentInformationApplication`](student_information::StudentInformationApplication)
 pub mod student_information;
 
-/// 채플 정보 조회: [`Chapel`](chapel::Chapel)
+/// 채플 정보 조회: [`ChapelApplication`](chapel::ChapelApplication)
 pub mod chapel;
 
-/// 개인 수업 시간표 조회: [`PersonalCourseSchedule`](personal_course_schedule::PersonalCourseSchedule)
+/// 개인 수업 시간표 조회: [`PersonalCourseScheduleApplication`](personal_course_schedule::PersonalCourseScheduleApplication)
 pub mod personal_course_schedule;
 
-/// 강의평가 조회: [`LectureAssessment`](lecture_assessment::LectureAssessment)
+/// 강의평가 조회: [`LectureAssessmentApplication`](lecture_assessment::LectureAssessmentApplication)
 pub mod lecture_assessment;

--- a/src/application/personal_course_schedule/mod.rs
+++ b/src/application/personal_course_schedule/mod.rs
@@ -1,4 +1,4 @@
-use model::PersonalCourseScheduleInformation;
+use model::PersonalCourseSchedule;
 
 use crate::{
     define_elements,
@@ -16,11 +16,11 @@ use crate::{
 use super::{USaintApplication, USaintClient};
 
 /// [개인수업시간표](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW2102)
-pub struct PersonalCourseSchedule {
+pub struct PersonalCourseScheduleApplication {
     client: USaintClient,
 }
 
-impl USaintApplication for PersonalCourseSchedule {
+impl USaintApplication for PersonalCourseScheduleApplication {
     const APP_NAME: &'static str = "ZCMW2102";
 
     fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
@@ -32,7 +32,7 @@ impl USaintApplication for PersonalCourseSchedule {
     }
 }
 
-impl<'a> PersonalCourseSchedule {
+impl<'a> PersonalCourseScheduleApplication {
     define_elements! {
         PERYR: ComboBox<'a> = "ZCMW_PERIOD_RE.ID_D8FB9BECD84FD622F5EAED9E0BE35D27:VIW_MAIN.PERYR";
         PERID: ComboBox<'a> = "ZCMW_PERIOD_RE.ID_D8FB9BECD84FD622F5EAED9E0BE35D27:VIW_MAIN.PERID";
@@ -82,7 +82,7 @@ impl<'a> PersonalCourseSchedule {
         &mut self,
         year: u32,
         semester: SemesterType,
-    ) -> Result<PersonalCourseScheduleInformation, RusaintError> {
+    ) -> Result<PersonalCourseSchedule, RusaintError> {
         self.select_semester(&year.to_string(), semester).await?;
         match Self::TABLE.from_body(self.body()) {
             Ok(table) => {
@@ -100,7 +100,7 @@ impl<'a> PersonalCourseSchedule {
                         })
                         .for_each(|(col_idx, str)| schedule[col_idx][row_idx] = str);
                 }
-                Ok(PersonalCourseScheduleInformation::new(schedule))
+                Ok(PersonalCourseSchedule::new(schedule))
             }
             Err(err) => match err {
                 WebDynproError::Element(ElementError::InvalidId(_id)) => Err(

--- a/src/application/personal_course_schedule/model.rs
+++ b/src/application/personal_course_schedule/model.rs
@@ -1,10 +1,10 @@
 /// 개인의 수업 시간표 정보를 조회합니다.
 #[derive(Clone, Debug)]
-pub struct PersonalCourseScheduleInformation {
+pub struct PersonalCourseSchedule {
     schedule: [[String; 10]; 7],
 }
 
-impl PersonalCourseScheduleInformation {
+impl PersonalCourseSchedule {
     pub(super) fn new(schedule: [[String; 10]; 7]) -> Self {
         Self { schedule }
     }

--- a/src/application/student_information/mod.rs
+++ b/src/application/student_information/mod.rs
@@ -1,7 +1,7 @@
 use model::{
-    GeneralStudentInformation, StudentAcademicRecordInformation, StudentBankAccountInformation,
-    StudentFamilyInformation, StudentGraduationInformation, StudentQualificationInformation,
-    StudentReligionInformation, StudentResearchBankAccountInformation, StudentTransferInformation,
+    StudentInformation, StudentAcademicRecords, StudentBankAccount,
+    StudentFamily, StudentGraduation, StudentQualification,
+    StudentReligion, StudentResearchBankAccount, StudentTransferRecords,
     StudentWorkInformation,
 };
 
@@ -14,11 +14,11 @@ use crate::{
 use super::{USaintApplication, USaintClient};
 
 /// [학생 정보 수정 및 조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW1001n)
-pub struct StudentInformation {
+pub struct StudentInformationApplication {
     client: USaintClient,
 }
 
-impl USaintApplication for StudentInformation {
+impl USaintApplication for StudentInformationApplication {
     const APP_NAME: &'static str = "ZCMW1001n";
 
     fn from_client(client: USaintClient) -> Result<Self, RusaintError> {
@@ -30,25 +30,25 @@ impl USaintApplication for StudentInformation {
     }
 }
 
-impl<'a> StudentInformation {
+impl<'a> StudentInformationApplication {
     // 부가정보 탭
     define_elements! {
         TAB_ADDITION: TabStrip<'a> = "ZCMW1001.ID_0001:VIW_MAIN.TAB_ADDITION";
     }
 
     /// 일반 학생 정보를 반환합니다.
-    pub fn general(&self) -> Result<GeneralStudentInformation, WebDynproError> {
-        GeneralStudentInformation::from_body(self.body())
+    pub fn general(&self) -> Result<StudentInformation, WebDynproError> {
+        StudentInformation::from_body(self.body())
     }
 
     /// 학생의 졸업과 관련된 정보를 반환합니다.
-    pub fn graduation(&self) -> Result<StudentGraduationInformation, WebDynproError> {
-        StudentGraduationInformation::from_body(self.body())
+    pub fn graduation(&self) -> Result<StudentGraduation, WebDynproError> {
+        StudentGraduation::from_body(self.body())
     }
 
     /// 학생의 교직, 평생교육사, 7+1 프로그램 등 자격 관련 정보를 반환합니다.
-    pub fn qualifications(&self) -> StudentQualificationInformation {
-        StudentQualificationInformation::from_body(self.body())
+    pub fn qualifications(&self) -> StudentQualification {
+        StudentQualification::from_body(self.body())
     }
 
     /// 학생의 직장 정보를 반환합니다.
@@ -57,37 +57,37 @@ impl<'a> StudentInformation {
     }
 
     /// 학생의 가족관계 정보를 반환합니다.
-    pub async fn family(&mut self) -> Result<StudentFamilyInformation, WebDynproError> {
-        StudentFamilyInformation::with_client(&mut self.client).await
+    pub async fn family(&mut self) -> Result<StudentFamily, WebDynproError> {
+        StudentFamily::with_client(&mut self.client).await
     }
 
     /// 학생의 종교 정보를 반환합니다.
-    pub async fn religion(&mut self) -> Result<StudentReligionInformation, WebDynproError> {
-        StudentReligionInformation::with_client(&mut self.client).await
+    pub async fn religion(&mut self) -> Result<StudentReligion, WebDynproError> {
+        StudentReligion::with_client(&mut self.client).await
     }
 
     /// 학생의 편입정보를 반환합니다.
-    pub async fn transfer(&mut self) -> Result<StudentTransferInformation, WebDynproError> {
-        StudentTransferInformation::with_client(&mut self.client).await
+    pub async fn transfer(&mut self) -> Result<StudentTransferRecords, WebDynproError> {
+        StudentTransferRecords::with_client(&mut self.client).await
     }
 
     /// 학생의 은행계좌 정보를 반환합니다.
-    pub async fn bank_account(&mut self) -> Result<StudentBankAccountInformation, WebDynproError> {
-        StudentBankAccountInformation::with_client(&mut self.client).await
+    pub async fn bank_account(&mut self) -> Result<StudentBankAccount, WebDynproError> {
+        StudentBankAccount::with_client(&mut self.client).await
     }
 
     /// 학생의 학적상태 정보를 반환합니다.
     pub async fn academic_record(
         &mut self,
-    ) -> Result<StudentAcademicRecordInformation, WebDynproError> {
-        StudentAcademicRecordInformation::with_client(&mut self.client).await
+    ) -> Result<StudentAcademicRecords, WebDynproError> {
+        StudentAcademicRecords::with_client(&mut self.client).await
     }
 
     /// 학생의 연구비 입금 계좌를 반환합니다.
     pub async fn research_bank_account(
         &mut self,
-    ) -> Result<StudentResearchBankAccountInformation, WebDynproError> {
-        StudentResearchBankAccountInformation::with_client(&mut self.client).await
+    ) -> Result<StudentResearchBankAccount, WebDynproError> {
+        StudentResearchBankAccount::with_client(&mut self.client).await
     }
 
     fn body(&self) -> &Body {

--- a/src/application/student_information/model/academic_record.rs
+++ b/src/application/student_information/model/academic_record.rs
@@ -3,16 +3,16 @@ use std::collections::HashMap;
 use serde::{de::{value::MapDeserializer, IntoDeserializer}, Deserialize};
 
 use crate::{
-    application::{student_information::StudentInformation, USaintClient}, define_elements, webdynpro::{command::element::layout::TabStripTabSelectCommand, element::{complex::{sap_table::FromSapTable, SapTable}, definition::ElementDefinition, layout::tab_strip::item::TabStripItem}, error::{ElementError, WebDynproError}}
+    application::{student_information::StudentInformationApplication, USaintClient}, define_elements, webdynpro::{command::element::layout::TabStripTabSelectCommand, element::{complex::{sap_table::FromSapTable, SapTable}, definition::ElementDefinition, layout::tab_strip::item::TabStripItem}, error::{ElementError, WebDynproError}}
 };
 
 #[derive(Clone, Debug)]
 /// 학생의 학적상태 정보
-pub struct StudentAcademicRecordInformation {
+pub struct StudentAcademicRecords {
     records: Vec<StudentAcademicRecord>,
 }
 
-impl<'a> StudentAcademicRecordInformation {
+impl<'a> StudentAcademicRecords {
     // 학적상태
     define_elements! {
         // 학적상태 탭
@@ -24,7 +24,7 @@ impl<'a> StudentAcademicRecordInformation {
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_READ_9600,
                 5,
                 0,

--- a/src/application/student_information/model/bank_account.rs
+++ b/src/application/student_information/model/bank_account.rs
@@ -1,18 +1,18 @@
 use crate::{
-    application::{student_information::StudentInformation, USaintClient}, define_elements, webdynpro::{command::element::layout::TabStripTabSelectCommand, element::{
+    application::{student_information::StudentInformationApplication, USaintClient}, define_elements, webdynpro::{command::element::layout::TabStripTabSelectCommand, element::{
         action::Button, definition::ElementDefinition, layout::tab_strip::item::TabStripItem, selection::ComboBox, text::InputField
     }, error::WebDynproError}
 };
 
 #[derive(Clone, Debug)]
 /// 학생의 은행 계좌 정보
-pub struct StudentBankAccountInformation {
+pub struct StudentBankAccount {
     bank: Option<String>,
     account_number: Option<String>,
     holder: Option<String>,
 }
 
-impl<'a> StudentBankAccountInformation {
+impl<'a> StudentBankAccount {
     // 은행계좌정보
     define_elements! {
         // 은행계좌정보 탭
@@ -32,7 +32,7 @@ impl<'a> StudentBankAccountInformation {
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_BANK_CP,
                 4,
                 0,

--- a/src/application/student_information/model/family.rs
+++ b/src/application/student_information/model/family.rs
@@ -6,7 +6,7 @@ use serde::{
 };
 
 use crate::{
-    application::{student_information::StudentInformation, USaintClient},
+    application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     utils::de_with::{deserialize_bool_string, deserialize_optional_string},
     webdynpro::{
@@ -22,11 +22,11 @@ use crate::{
 
 #[derive(Clone, Debug)]
 /// 학생의 가족관계 정보
-pub struct StudentFamilyInformation {
+pub struct StudentFamily {
     members: Vec<StudentFamilyMember>,
 }
 
-impl<'a> StudentFamilyInformation {
+impl<'a> StudentFamily {
     // 가족사항
     define_elements! {
         // 가족사항 탭
@@ -38,7 +38,7 @@ impl<'a> StudentFamilyInformation {
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_FAMILY,
                 1,
                 0,

--- a/src/application/student_information/model/graduation.rs
+++ b/src/application/student_information/model/graduation.rs
@@ -2,7 +2,7 @@ use crate::{define_elements, webdynpro::{client::body::Body, element::{definitio
 
 #[derive(Clone, Debug)]
 /// 학생의 졸업 정보를 반환합니다. 졸업하지 않았다면 반환되지 않습니다.
-pub struct StudentGraduationInformation {
+pub struct StudentGraduation {
   graduation_cardinal: u32,
   graduation_certification_number: u32,
   graduation_year: u32,
@@ -15,7 +15,7 @@ pub struct StudentGraduationInformation {
   graduation_personnel_number: u32,
 }
 
-impl<'a> StudentGraduationInformation {
+impl<'a> StudentGraduation {
   define_elements! {
       // 졸업회수
       GRDU_NO: InputField<'a> = "ZCMW1001.ID_0001:VIW_DEFAULT.TC_DEFAULT_GRDU_NO";
@@ -39,7 +39,7 @@ impl<'a> StudentGraduationInformation {
       TDPT_NUMBER: InputField<'a> = "ZCMW1001.ID_0001:VIW_DEFAULT.TC_DEFAULT_TDPT_NUMBER";
   }
 
-  pub(crate) fn from_body(body: &'a Body) -> Result<StudentGraduationInformation, WebDynproError> {
+  pub(crate) fn from_body(body: &'a Body) -> Result<StudentGraduation, WebDynproError> {
     let graduation_year = Self::GRDU_PERYR.from_body(body)?.value_into_u32()?;
     if graduation_year == 0 {
       Err(WebDynproError::Element(ElementError::NoSuchContent { element: Self::GRDU_NO.id().to_string(), content: "No graduation information provided. Is this student graduated?".to_string() }))

--- a/src/application/student_information/model/mod.rs
+++ b/src/application/student_information/model/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[derive(Clone, Debug)]
 /// 기본 학생 정보
-pub struct GeneralStudentInformation {
+pub struct StudentInformation {
     apply_year: u32,
     student_number: u32,
     name: String,
@@ -41,7 +41,7 @@ pub struct GeneralStudentInformation {
     abeek: Option<String>,
 }
 
-impl<'a> GeneralStudentInformation {
+impl<'a> StudentInformation {
     define_elements! {
         // 입학 년도
         APPLY_PERYR: InputField<'a> = "ZCMW1001.ID_0001:VIW_DEFAULT.APPLY_PERYR";
@@ -116,7 +116,7 @@ impl<'a> GeneralStudentInformation {
         CG_STEXT4: InputField<'a> = "ZCMW1001.ID_0001:VIW_DEFAULT.TC_DEFAULT_CG_STEXT4";
     }
 
-    pub(super) fn from_body(body: &'a Body) -> Result<GeneralStudentInformation, WebDynproError> {
+    pub(super) fn from_body(body: &'a Body) -> Result<StudentInformation, WebDynproError> {
         Ok(Self {
             apply_year: Self::APPLY_PERYR.from_body(body)?.value_into_u32()?,
             student_number: Self::STUDENT12.from_body(body)?.value_into_u32()?,
@@ -302,15 +302,15 @@ mod research_bank_account;
 mod transfer;
 mod work;
 
-pub use academic_record::{StudentAcademicRecord, StudentAcademicRecordInformation};
-pub use bank_account::StudentBankAccountInformation;
-pub use family::{StudentFamilyInformation, StudentFamilyMember};
-pub use graduation::StudentGraduationInformation;
+pub use academic_record::{StudentAcademicRecord, StudentAcademicRecords};
+pub use bank_account::StudentBankAccount;
+pub use family::{StudentFamily, StudentFamilyMember};
+pub use graduation::StudentGraduation;
 pub use qualification::{
-    StudentForignStudyInformation, StudentLifelongInformation, StudentQualificationInformation,
+    StudentForignStudyInformation, StudentLifelongInformation, StudentQualification,
     StudentTeachingMajorInformation, StudentTeachingPluralMajorInformation,
 };
-pub use religion::StudentReligionInformation;
-pub use research_bank_account::StudentResearchBankAccountInformation;
-pub use transfer::{StudentTransferInformation, StudentTransferRecord};
+pub use religion::StudentReligion;
+pub use research_bank_account::StudentResearchBankAccount;
+pub use transfer::{StudentTransferRecords, StudentTransferRecord};
 pub use work::StudentWorkInformation;

--- a/src/application/student_information/model/qualification.rs
+++ b/src/application/student_information/model/qualification.rs
@@ -9,15 +9,15 @@ use crate::{
 
 #[derive(Clone, Debug)]
 /// 학생의 자격(교직이수, 평생교육사, 7+1 프로그램) 정보
-pub struct StudentQualificationInformation {
+pub struct StudentQualification {
     teaching_major: Option<StudentTeachingMajorInformation>,
     teaching_plural_major: Option<StudentTeachingPluralMajorInformation>,
     lifelong: Option<StudentLifelongInformation>,
     forign_study: Option<StudentForignStudyInformation>,
 }
 
-impl<'a> StudentQualificationInformation {
-    pub(crate) fn from_body(body: &'a Body) -> StudentQualificationInformation {
+impl<'a> StudentQualification {
+    pub(crate) fn from_body(body: &'a Body) -> StudentQualification {
         Self {
             teaching_major: StudentTeachingMajorInformation::from_body(body).ok(),
             teaching_plural_major: StudentTeachingPluralMajorInformation::from_body(body).ok(),

--- a/src/application/student_information/model/religion.rs
+++ b/src/application/student_information/model/religion.rs
@@ -1,5 +1,5 @@
 use crate::{
-    application::{student_information::StudentInformation, USaintClient},
+    application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
         command::element::layout::TabStripTabSelectCommand,
@@ -13,7 +13,7 @@ use crate::{
 
 #[derive(Clone, Debug)]
 /// 학생의 종교 정보
-pub struct StudentReligionInformation {
+pub struct StudentReligion {
     religion_type: Option<String>,
     start_date: Option<String>,
     church: Option<String>,
@@ -30,7 +30,7 @@ pub struct StudentReligionInformation {
     church_grp: Option<String>,
 }
 
-impl<'a> StudentReligionInformation {
+impl<'a> StudentReligion {
     // 종교
     define_elements! {
         // 종교 탭
@@ -72,7 +72,7 @@ impl<'a> StudentReligionInformation {
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_RELIGION,
                 2,
                 0,

--- a/src/application/student_information/model/research_bank_account.rs
+++ b/src/application/student_information/model/research_bank_account.rs
@@ -1,5 +1,5 @@
 use crate::{
-    application::{student_information::StudentInformation, USaintClient},
+    application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
         command::element::layout::TabStripTabSelectCommand,
@@ -13,13 +13,13 @@ use crate::{
 
 #[derive(Clone, Debug)]
 /// 연구비 입급 계좌 정보
-pub struct StudentResearchBankAccountInformation {
+pub struct StudentResearchBankAccount {
     bank: Option<String>,
     account_number: Option<String>,
     holder: Option<String>,
 }
 
-impl<'a> StudentResearchBankAccountInformation {
+impl<'a> StudentResearchBankAccount {
     // 연구비 입금 계좌
     define_elements! {
         // 연구비 입금 계좌 탭
@@ -39,7 +39,7 @@ impl<'a> StudentResearchBankAccountInformation {
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_RES_ACCOUNT,
                 6,
                 0,

--- a/src/application/student_information/model/transfer.rs
+++ b/src/application/student_information/model/transfer.rs
@@ -3,16 +3,16 @@ use std::collections::HashMap;
 use serde::{de::{value::MapDeserializer, IntoDeserializer}, Deserialize};
 
 use crate::{
-    application::{student_information::StudentInformation, USaintClient}, define_elements, webdynpro::{command::element::layout::TabStripTabSelectCommand, element::{complex::{sap_table::FromSapTable, SapTable}, definition::ElementDefinition, layout::tab_strip::item::TabStripItem}, error::{ElementError, WebDynproError}}
+    application::{student_information::StudentInformationApplication, USaintClient}, define_elements, webdynpro::{command::element::layout::TabStripTabSelectCommand, element::{complex::{sap_table::FromSapTable, SapTable}, definition::ElementDefinition, layout::tab_strip::item::TabStripItem}, error::{ElementError, WebDynproError}}
 };
 
 #[derive(Clone, Debug)]
 /// 학생 편입 정보
-pub struct StudentTransferInformation {
+pub struct StudentTransferRecords {
     records: Vec<StudentTransferRecord>,
 }
 
-impl<'a> StudentTransferInformation {
+impl<'a> StudentTransferRecords {
     // 편입정보
     define_elements! {
         // 편입정보 탭
@@ -24,7 +24,7 @@ impl<'a> StudentTransferInformation {
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_TRANSFER,
                 3,
                 0,

--- a/src/application/student_information/model/work.rs
+++ b/src/application/student_information/model/work.rs
@@ -1,5 +1,5 @@
 use crate::{
-    application::{student_information::StudentInformation, USaintClient},
+    application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
         command::element::layout::TabStripTabSelectCommand,
@@ -61,7 +61,7 @@ impl<'a> StudentWorkInformation {
     ) -> Result<StudentWorkInformation, WebDynproError> {
         client
             .send(TabStripTabSelectCommand::new(
-                StudentInformation::TAB_ADDITION,
+                StudentInformationApplication::TAB_ADDITION,
                 Self::TAB_WORK,
                 0,
                 0,

--- a/tests/application/chapel.rs
+++ b/tests/application/chapel.rs
@@ -1,5 +1,5 @@
 use rusaint::{
-    application::{chapel::Chapel, USaintClientBuilder},
+    application::{chapel::ChapelApplication, USaintClientBuilder},
     model::SemesterType,
     ApplicationError, RusaintError,
 };
@@ -13,7 +13,7 @@ async fn chapel() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<Chapel>()
+        .build_into::<ChapelApplication>()
         .await
         .unwrap();
     let info = app.information(2022, SemesterType::Two).await.unwrap();
@@ -26,7 +26,7 @@ async fn no_chapel() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<Chapel>()
+        .build_into::<ChapelApplication>()
         .await
         .unwrap();
     let info = app.information(2024, SemesterType::Two).await.unwrap_err();

--- a/tests/application/course_grades.rs
+++ b/tests/application/course_grades.rs
@@ -1,6 +1,6 @@
 use rusaint::{
     application::{
-        course_grades::{model::CourseType, CourseGrades},
+        course_grades::{model::CourseType, CourseGradesApplication},
         USaintClientBuilder,
     },
     model::SemesterType,
@@ -15,7 +15,7 @@ async fn recorded_summary() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<CourseGrades>()
+        .build_into::<CourseGradesApplication>()
         .await
         .unwrap();
     let recorded_summary = app.recorded_summary(CourseType::Bachelor).await.unwrap();
@@ -33,7 +33,7 @@ async fn certificated_summary() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<CourseGrades>()
+        .build_into::<CourseGradesApplication>()
         .await
         .unwrap();
     let certificated_summary = app
@@ -49,7 +49,7 @@ async fn semesters() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<CourseGrades>()
+        .build_into::<CourseGradesApplication>()
         .await
         .unwrap();
     let semesters = app.semesters(CourseType::Bachelor).await.unwrap();
@@ -63,7 +63,7 @@ async fn classes_with_detail() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<CourseGrades>()
+        .build_into::<CourseGradesApplication>()
         .await
         .unwrap();
     let details = app

--- a/tests/application/course_schedule.rs
+++ b/tests/application/course_schedule.rs
@@ -1,6 +1,6 @@
 use rusaint::{
     application::{
-        course_schedule::{model::LectureCategory, CourseSchedule},
+        course_schedule::{model::LectureCategory, CourseScheduleApplication},
         USaintClientBuilder,
     },
     model::SemesterType,
@@ -16,7 +16,7 @@ async fn find_major() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<CourseSchedule>()
+        .build_into::<CourseScheduleApplication>()
         .await
         .unwrap();
     let category = LectureCategory::major("IT대학", "글로벌미디어학부", None);
@@ -36,7 +36,7 @@ async fn find_nothing() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<CourseSchedule>()
+        .build_into::<CourseScheduleApplication>()
         .await
         .unwrap();
     let category = LectureCategory::find_by_lecture("내가A+받는강의");

--- a/tests/application/graduation_requirements.rs
+++ b/tests/application/graduation_requirements.rs
@@ -1,4 +1,4 @@
-use rusaint::application::{graduation_requirements::GraduationRequirements, USaintClientBuilder};
+use rusaint::application::{graduation_requirements::GraduationRequirementsApplication, USaintClientBuilder};
 use serial_test::serial;
 
 use crate::get_session;
@@ -9,7 +9,7 @@ async fn student_info() {
     let session = get_session().await.unwrap();
     let app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<GraduationRequirements>()
+        .build_into::<GraduationRequirementsApplication>()
         .await
         .unwrap();
     let student_info = app.student_info().await.unwrap();
@@ -22,7 +22,7 @@ async fn graduation_requirements() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<GraduationRequirements>()
+        .build_into::<GraduationRequirementsApplication>()
         .await
         .unwrap();
     let graduation_requirements = app.requirements().await.unwrap();

--- a/tests/application/lecture_assessment.rs
+++ b/tests/application/lecture_assessment.rs
@@ -1,5 +1,5 @@
 use rusaint::{
-    application::{lecture_assessment::LectureAssessment, USaintClientBuilder},
+    application::{lecture_assessment::LectureAssessmentApplication, USaintClientBuilder},
     model::SemesterType,
 };
 use serial_test::serial;
@@ -12,7 +12,7 @@ async fn lecture_assessment() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<LectureAssessment>()
+        .build_into::<LectureAssessmentApplication>()
         .await
         .unwrap();
     let info = app

--- a/tests/application/personal_course_schedule.rs
+++ b/tests/application/personal_course_schedule.rs
@@ -1,5 +1,5 @@
 use rusaint::{
-    application::{personal_course_schedule::PersonalCourseSchedule, USaintClientBuilder},
+    application::{personal_course_schedule::PersonalCourseScheduleApplication, USaintClientBuilder},
     model::SemesterType,
     ApplicationError, RusaintError,
 };
@@ -13,7 +13,7 @@ async fn schedule() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<PersonalCourseSchedule>()
+        .build_into::<PersonalCourseScheduleApplication>()
         .await
         .unwrap();
     let info = app.schedule(2022, SemesterType::Two).await.unwrap();
@@ -26,7 +26,7 @@ async fn no_schedule() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<PersonalCourseSchedule>()
+        .build_into::<PersonalCourseScheduleApplication>()
         .await
         .unwrap();
     let info = app.schedule(2024, SemesterType::Two).await.unwrap_err();

--- a/tests/application/student_information.rs
+++ b/tests/application/student_information.rs
@@ -1,4 +1,4 @@
-use rusaint::{application::{student_information::StudentInformation, USaintClientBuilder}, webdynpro::error::{ElementError, WebDynproError}};
+use rusaint::{application::{student_information::StudentInformationApplication, USaintClientBuilder}, webdynpro::error::{ElementError, WebDynproError}};
 use serial_test::serial;
 
 use crate::get_session;
@@ -9,7 +9,7 @@ async fn general() {
     let session = get_session().await.unwrap();
     let app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.general().unwrap();
@@ -22,7 +22,7 @@ async fn graduation() {
     let session = get_session().await.unwrap();
     let app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.graduation();
@@ -42,7 +42,7 @@ async fn qualifications() {
     let session = get_session().await.unwrap();
     let app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.qualifications();
@@ -55,7 +55,7 @@ async fn work() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.work().await.unwrap();
@@ -68,7 +68,7 @@ async fn family() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.family().await.unwrap();
@@ -81,7 +81,7 @@ async fn religion() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.religion().await.unwrap();
@@ -94,7 +94,7 @@ async fn transfer() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.transfer().await.unwrap();
@@ -107,7 +107,7 @@ async fn bank_account() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.bank_account().await.unwrap();
@@ -120,7 +120,7 @@ async fn academic_record() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.academic_record().await.unwrap();
@@ -133,7 +133,7 @@ async fn research_bank_account() {
     let session = get_session().await.unwrap();
     let mut app = USaintClientBuilder::new()
         .session(session)
-        .build_into::<StudentInformation>()
+        .build_into::<StudentInformationApplication>()
         .await
         .unwrap();
     let student_info = app.research_bank_account().await.unwrap();


### PR DESCRIPTION
# What's in this pull request
- `impl USaintApplication` 인 모든 구조체에 `-Application` 접미사를 추가했습니다.
  - 애플리케이션 명을 호출하는 경우는 적고, 애플리케이션들이 Application 접미사를 가지지 않음으로써 해당 애플리케이션에서 사용하는 모델들의 이름이 모호해지거나 지나치게 길어지는 문제를 해결하기 위함입니다.