### PR TITLE
[refactor] `scraper` 없이 `SapSsrClient` 파싱

### DIFF
--- a/rusaint/src/webdynpro/client/mod.rs
+++ b/rusaint/src/webdynpro/client/mod.rs
@@ -285,6 +285,7 @@ impl Requests for reqwest::Client {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct SapSsrClient {
     action: String,
     charset: String,


### PR DESCRIPTION
# What's in this pull request
- `scraper` 의존성 없이 `roxmltree`와 `regex_lite`만을 활용하여 `SapSsrClient`를 파싱합니다.
- #90 를 위해 직접 엘리먼트를 파싱하는 경우가 아니라면 HTML 파서를 제외해 라이브러리 경량화를 달성하기 위함입니다.