### PR TITLE
[fix] `crates.io` 에서 `README`가 불러와지지 않는 문제 수정

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [ "rusaint", "rusaint-ffi", "uniffi-bindgen" ]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 
 keywords = ["ssu", "u-saint", "scraping", "parser"]
 authors = ["Hyomin Koo <me@eatsteak.dev>"]
@@ -11,6 +11,7 @@ license = "MIT"
 homepage = "https://eatsteak.dev"
 repository = "https://github.com/EATSTEAK/rusaint"
 edition = "2021"
+readme = "README.md"
 
 [workspace.dependencies]
 thiserror = "1.0.44"

--- a/rusaint/Cargo.toml
+++ b/rusaint/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
+readme.workspace = true
 
 [features]
 default = ["application"]


### PR DESCRIPTION
# What's in this pull request
- workspace 설정으로 바꾼 뒤, `crates.io` 에서 `README`가 표시되지 않는 문제 수정