### PR TITLE
[BREAKING] Command 명명 방식 변경

### DIFF
--- a/rusaint/src/application/chapel/mod.rs
+++ b/rusaint/src/application/chapel/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     webdynpro::{
         client::body::Body,
         command::element::{
-            action::ButtonPressCommand,
-            selection::{ComboBoxSelectCommand, ReadComboBoxLSDataCommand},
+            action::ButtonPressEventCommand,
+            selection::{ComboBoxLSDataCommand, ComboBoxSelectEventCommand},
         },
         element::{action::Button, selection::ComboBox},
         error::{ElementError, WebDynproError},
@@ -62,22 +62,27 @@ impl<'a> ChapelApplication {
     ) -> Result<(), RusaintError> {
         let semester = Self::semester_to_key(semester);
         let parser = ElementParser::new(self.body());
-        let year_combobox_lsdata = parser.read(ReadComboBoxLSDataCommand::new(Self::SEL_PERYR))?;
-        let semester_combobox_lsdata =
-            parser.read(ReadComboBoxLSDataCommand::new(Self::SEL_PERID))?;
+        let year_combobox_lsdata = parser.read(ComboBoxLSDataCommand::new(Self::SEL_PERYR))?;
+        let semester_combobox_lsdata = parser.read(ComboBoxLSDataCommand::new(Self::SEL_PERID))?;
         if year_combobox_lsdata.key().map(String::as_str) != Some(year) {
-            let year_select_event =
-                parser.read(ComboBoxSelectCommand::new(Self::SEL_PERYR, &year, false))?;
+            let year_select_event = parser.read(ComboBoxSelectEventCommand::new(
+                Self::SEL_PERYR,
+                &year,
+                false,
+            ))?;
             self.client.process_event(false, year_select_event).await?;
         }
         if semester_combobox_lsdata.key().map(String::as_str) != Some(semester) {
-            let semester_select_event =
-                parser.read(ComboBoxSelectCommand::new(Self::SEL_PERID, semester, false))?;
+            let semester_select_event = parser.read(ComboBoxSelectEventCommand::new(
+                Self::SEL_PERID,
+                semester,
+                false,
+            ))?;
             self.client
                 .process_event(false, semester_select_event)
                 .await?;
         }
-        let button_press_event = parser.read(ButtonPressCommand::new(Self::BTN_SEL))?;
+        let button_press_event = parser.read(ButtonPressEventCommand::new(Self::BTN_SEL))?;
         self.client.process_event(false, button_press_event).await?;
         Ok(())
     }

--- a/rusaint/src/application/chapel/model.rs
+++ b/rusaint/src/application/chapel/model.rs
@@ -13,7 +13,7 @@ use crate::{
     model::SemesterType,
     utils::de_with::{deserialize_semester_type, deserialize_u32_string},
     webdynpro::{
-        command::element::complex::ReadSapTableBodyCommand,
+        command::element::complex::SapTableBodyCommand,
         element::{
             complex::{
                 sap_table::{
@@ -121,7 +121,7 @@ impl<'a> GeneralChapelInformation {
     }
 
     pub(crate) fn with_parser(parser: &'a ElementParser) -> Result<Vec<Self>, RusaintError> {
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::TABLE))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::TABLE))?;
         let Some(first_row) = table.iter().next() else {
             return Err(ApplicationError::NoChapelInformation.into());
         };
@@ -228,7 +228,7 @@ impl<'a> ChapelAttendance {
     }
 
     pub(crate) fn with_parser(parser: &'a ElementParser) -> Result<Vec<Self>, WebDynproError> {
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::TABLE_A))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_A))?;
         let Some(first_row) = table.iter().next() else {
             return Ok(Vec::with_capacity(0));
         };
@@ -346,7 +346,7 @@ impl<'a> ChapelAbsenceRequest {
         TABLE02_CP_CP: SapTable<'a> = "ZCMW3681.ID_0001:V_MAIN.TABLE02_CP_CP";
     }
     pub(crate) fn with_parser(parser: &'a ElementParser) -> Result<Vec<Self>, RusaintError> {
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::TABLE02_CP_CP))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::TABLE02_CP_CP))?;
         let Some(first_row) = table.iter().next() else {
             return Ok(Vec::with_capacity(0));
         };

--- a/rusaint/src/application/course_schedule/mod.rs
+++ b/rusaint/src/application/course_schedule/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     model::SemesterType,
     webdynpro::{
         client::body::Body,
-        command::element::{complex::ReadSapTableBodyCommand, selection::ComboBoxSelectCommand},
+        command::element::{complex::SapTableBodyCommand, selection::ComboBoxSelectEventCommand},
         element::{
             complex::{
                 sap_table::cell::{SapTableCell, SapTableCellWrapper},
@@ -65,10 +65,13 @@ impl<'a> CourseScheduleApplication {
         year: &str,
         period: SemesterType,
     ) -> Result<(), WebDynproError> {
-        let year_select_event =
-            parser.read(ComboBoxSelectCommand::new(Self::PERIOD_YEAR, year, false))?;
+        let year_select_event = parser.read(ComboBoxSelectEventCommand::new(
+            Self::PERIOD_YEAR,
+            year,
+            false,
+        ))?;
         self.client.process_event(false, year_select_event).await?;
-        let semester_select_event = parser.read(ComboBoxSelectCommand::new(
+        let semester_select_event = parser.read(ComboBoxSelectEventCommand::new(
             Self::PERIOD_ID,
             Self::semester_to_key(period),
             false,
@@ -84,7 +87,7 @@ impl<'a> CourseScheduleApplication {
         parser: &ElementParser,
         row: u32,
     ) -> Result<(), WebDynproError> {
-        let event = parser.read(ComboBoxSelectCommand::new(
+        let event = parser.read(ComboBoxSelectEventCommand::new(
             Self::TABLE_ROWS,
             row.to_string().as_str(),
             false,
@@ -103,7 +106,7 @@ impl<'a> CourseScheduleApplication {
         year: u32,
         period: SemesterType,
         lecture_category: &LectureCategory,
-    ) -> Result<impl Iterator<Item=Lecture>, RusaintError> {
+    ) -> Result<impl Iterator<Item = Lecture>, RusaintError> {
         {
             let parser = ElementParser::new(self.body());
             let year_str = format!("{}", year);
@@ -112,7 +115,7 @@ impl<'a> CourseScheduleApplication {
         }
         lecture_category.request_query(&mut self.client.0).await?;
         let parser = ElementParser::new(self.body());
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::MAIN_TABLE))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::MAIN_TABLE))?;
         let Some(first_row) = table.iter().next() else {
             return Err(ApplicationError::NoLectureResult.into());
         };

--- a/rusaint/src/application/course_schedule/model.rs
+++ b/rusaint/src/application/course_schedule/model.rs
@@ -13,9 +13,9 @@ use crate::{
     webdynpro::{
         client::WebDynproClient,
         command::element::{
-            action::ButtonPressCommand,
-            layout::TabStripTabSelectCommand,
-            selection::{ComboBoxChangeCommand, ComboBoxSelectByValue1Command},
+            action::ButtonPressEventCommand,
+            layout::TabStripTabSelectEventCommand,
+            selection::{ComboBoxChangeEventCommand, ComboBoxSelectByValue1EventCommand},
         },
         element::{
             action::{Button, ButtonDef},
@@ -222,7 +222,7 @@ impl LectureCategory {
                         department,
                         major,
                     )
-                        .await?;
+                    .await?;
                 } else {
                     Self::request_lv2(
                         client,
@@ -234,7 +234,7 @@ impl LectureCategory {
                         collage,
                         department,
                     )
-                        .await?;
+                    .await?;
                 }
             }
             LectureCategory::RequiredElective { lecture_name } => {
@@ -252,7 +252,7 @@ impl LectureCategory {
                     SEARCH_GENERAL_REQ,
                     lecture_name,
                 )
-                    .await?;
+                .await?;
             }
             LectureCategory::OptionalElective { category } => {
                 // 교양선택
@@ -269,7 +269,7 @@ impl LectureCategory {
                     SEARCH_GENERAL_OPT,
                     category,
                 )
-                    .await?;
+                .await?;
             }
             LectureCategory::Chapel { lecture_name } => {
                 // 채플
@@ -286,7 +286,7 @@ impl LectureCategory {
                     SEARCH_CHAPEL,
                     lecture_name,
                 )
-                    .await?;
+                .await?;
             }
             LectureCategory::Education => {
                 // 교직
@@ -317,7 +317,7 @@ impl LectureCategory {
                     collage,
                     department,
                 )
-                    .await?;
+                .await?;
             }
             LectureCategory::ConnectedMajor { major } => {
                 // 연계전공
@@ -352,7 +352,7 @@ impl LectureCategory {
                     SEARCH_PROFESSOR,
                     keyword,
                 )
-                    .await?;
+                .await?;
             }
             LectureCategory::FindByLecture { keyword } => {
                 // 과목검색
@@ -390,7 +390,7 @@ impl LectureCategory {
                         department,
                         major,
                     )
-                        .await?;
+                    .await?;
                 } else {
                     Self::request_lv2(
                         client,
@@ -402,7 +402,7 @@ impl LectureCategory {
                         collage,
                         department,
                     )
-                        .await?;
+                    .await?;
                 }
             }
             LectureCategory::Cyber => {
@@ -429,23 +429,24 @@ impl LectureCategory {
         value_lv2: &str,
         value_lv3: &str,
     ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(TabStripTabSelectCommand::new(
-            Self::TABSTRIP,
-            tab_item,
-            tab_index,
-            0,
-        ))?;
+        let tab_select = ElementParser::new(client.body()).read(
+            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
+        )?;
         client.process_event(false, tab_select).await?;
-        let lv1_event = ElementParser::new(client.body())
-            .read(ComboBoxSelectByValue1Command::new(lv1, value_lv1, false))?;
+        let lv1_event = ElementParser::new(client.body()).read(
+            ComboBoxSelectByValue1EventCommand::new(lv1, value_lv1, false),
+        )?;
         client.process_event(false, lv1_event).await?;
-        let lv2_event = ElementParser::new(client.body())
-            .read(ComboBoxSelectByValue1Command::new(lv2, value_lv2, false))?;
+        let lv2_event = ElementParser::new(client.body()).read(
+            ComboBoxSelectByValue1EventCommand::new(lv2, value_lv2, false),
+        )?;
         client.process_event(false, lv2_event).await?;
         let parser = ElementParser::new(client.body());
-        let lv3_event = parser.read(ComboBoxSelectByValue1Command::new(lv3, value_lv3, false))?;
+        let lv3_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+            lv3, value_lv3, false,
+        ))?;
         client.process_event(false, lv3_event).await?;
-        let btn_press = parser.read(ButtonPressCommand::new(search_btn))?;
+        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
         client.process_event(false, btn_press).await?;
         Ok(())
     }
@@ -460,20 +461,20 @@ impl LectureCategory {
         value_lv1: &str,
         value_lv2: &str,
     ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(TabStripTabSelectCommand::new(
-            Self::TABSTRIP,
-            tab_item,
-            tab_index,
-            0,
-        ))?;
+        let tab_select = ElementParser::new(client.body()).read(
+            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
+        )?;
         client.process_event(false, tab_select).await?;
-        let lv1_event = ElementParser::new(client.body())
-            .read(ComboBoxSelectByValue1Command::new(lv1, value_lv1, false))?;
+        let lv1_event = ElementParser::new(client.body()).read(
+            ComboBoxSelectByValue1EventCommand::new(lv1, value_lv1, false),
+        )?;
         client.process_event(false, lv1_event).await?;
         let parser = ElementParser::new(client.body());
-        let lv2_event = parser.read(ComboBoxSelectByValue1Command::new(lv2, value_lv2, false))?;
+        let lv2_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+            lv2, value_lv2, false,
+        ))?;
         client.process_event(false, lv2_event).await?;
-        let btn_press = parser.read(ButtonPressCommand::new(search_btn))?;
+        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
         client.process_event(false, btn_press).await?;
         Ok(())
     }
@@ -486,17 +487,16 @@ impl LectureCategory {
         search_btn: ButtonDef,
         value_lv1: &str,
     ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(TabStripTabSelectCommand::new(
-            Self::TABSTRIP,
-            tab_item,
-            tab_index,
-            0,
-        ))?;
+        let tab_select = ElementParser::new(client.body()).read(
+            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
+        )?;
         client.process_event(false, tab_select).await?;
         let parser = ElementParser::new(client.body());
-        let lv1_event = parser.read(ComboBoxSelectByValue1Command::new(lv1, value_lv1, false))?;
+        let lv1_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+            lv1, value_lv1, false,
+        ))?;
         client.process_event(false, lv1_event).await?;
-        let btn_press = parser.read(ButtonPressCommand::new(search_btn))?;
+        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
         client.process_event(false, btn_press).await?;
         Ok(())
     }
@@ -509,17 +509,14 @@ impl LectureCategory {
         search_btn: ButtonDef,
         value: &str,
     ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(TabStripTabSelectCommand::new(
-            Self::TABSTRIP,
-            tab_item,
-            tab_index,
-            0,
-        ))?;
+        let tab_select = ElementParser::new(client.body()).read(
+            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
+        )?;
         client.process_event(false, tab_select).await?;
         let parser = ElementParser::new(client.body());
-        let change = parser.read(ComboBoxChangeCommand::new(text_combo, value, false))?;
+        let change = parser.read(ComboBoxChangeEventCommand::new(text_combo, value, false))?;
         client.process_event(false, change).await?;
-        let btn_press = parser.read(ButtonPressCommand::new(search_btn))?;
+        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
         client.process_event(false, btn_press).await?;
         Ok(())
     }
@@ -530,15 +527,12 @@ impl LectureCategory {
         tab_index: u32,
         search_btn: ButtonDef,
     ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(TabStripTabSelectCommand::new(
-            Self::TABSTRIP,
-            tab_item,
-            tab_index,
-            0,
-        ))?;
+        let tab_select = ElementParser::new(client.body()).read(
+            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
+        )?;
         client.process_event(false, tab_select).await?;
         let btn_press =
-            ElementParser::new(client.body()).read(ButtonPressCommand::new(search_btn))?;
+            ElementParser::new(client.body()).read(ButtonPressEventCommand::new(search_btn))?;
         client.process_event(false, btn_press).await?;
         Ok(())
     }

--- a/rusaint/src/application/graduation_requirements/mod.rs
+++ b/rusaint/src/application/graduation_requirements/mod.rs
@@ -8,8 +8,8 @@ use crate::{
     webdynpro::{
         client::body::Body,
         command::element::{
-            action::ButtonPressCommand, complex::ReadSapTableBodyCommand,
-            text::ReadInputFieldValueCommand,
+            action::ButtonPressEventCommand, complex::SapTableBodyCommand,
+            text::InputFieldValueCommand,
         },
         element::{
             action::Button,
@@ -143,14 +143,14 @@ impl<'a> GraduationRequirementsApplication {
     pub async fn requirements(&mut self) -> Result<GraduationRequirements, RusaintError> {
         {
             let event = ElementParser::new(self.body())
-                .read(ButtonPressCommand::new(Self::SHOW_DETAILS))?;
+                .read(ButtonPressEventCommand::new(Self::SHOW_DETAILS))?;
             self.client.process_event(false, event).await?;
         }
         let parser = ElementParser::new(self.body());
         let audit_result = parser
-            .read(ReadInputFieldValueCommand::new(Self::AUDIT_RESULT))
+            .read(InputFieldValueCommand::new(Self::AUDIT_RESULT))
             .is_ok_and(|str| str == "가능");
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::MAIN_TABLE))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::MAIN_TABLE))?;
         let requirements = table
             .try_table_into::<GraduationRequirement>(&parser)?
             .into_iter()
@@ -177,7 +177,7 @@ mod test {
             graduation_requirements::GraduationRequirementsApplication, USaintClientBuilder,
         },
         global_test_utils::get_session,
-        webdynpro::command::element::complex::ReadSapTableBodyCommand,
+        webdynpro::command::element::complex::SapTableBodyCommand,
     };
 
     #[tokio::test]
@@ -191,7 +191,7 @@ mod test {
             .unwrap();
         let parser = ElementParser::new(app.body());
         let table = parser
-            .read(ReadSapTableBodyCommand::new(
+            .read(SapTableBodyCommand::new(
                 GraduationRequirementsApplication::MAIN_TABLE,
             ))
             .unwrap()

--- a/rusaint/src/application/mod.rs
+++ b/rusaint/src/application/mod.rs
@@ -9,7 +9,8 @@ use crate::{
     webdynpro::{
         client::{body::Body, EventProcessResult, WebDynproClient, WebDynproClientBuilder},
         command::element::system::{
-            ClientInspectorNotifyCommand, CustomClientInfoCommand, LoadingPlaceholderLoadCommand,
+            ClientInspectorNotifyEventCommand, CustomClientInfoEventCommand,
+            LoadingPlaceholderLoadEventCommand,
         },
         element::{
             define_elements,
@@ -73,18 +74,18 @@ impl<'a> USaintClient {
 
     async fn load_placeholder(&mut self) -> Result<(), WebDynproError> {
         let parser = ElementParser::new(self.body());
-        let notify_wd01 = parser.read(ClientInspectorNotifyCommand::new(
+        let notify_wd01 = parser.read(ClientInspectorNotifyEventCommand::new(
             Self::CLIENT_INSPECTOR_WD01,
             INITIAL_CLIENT_DATA_WD01,
         ))?;
-        let notify_wd02 = parser.read(ClientInspectorNotifyCommand::new(
+        let notify_wd02 = parser.read(ClientInspectorNotifyEventCommand::new(
             Self::CLIENT_INSPECTOR_WD02,
             INITIAL_CLIENT_DATA_WD02,
         ))?;
-        let load = parser.read(LoadingPlaceholderLoadCommand::new(
+        let load = parser.read(LoadingPlaceholderLoadEventCommand::new(
             Self::LOADING_PLACEHOLDER,
         ))?;
-        let custom = parser.read(CustomClientInfoCommand::new(
+        let custom = parser.read(CustomClientInfoEventCommand::new(
             Self::CUSTOM,
             CustomClientInfo {
                 client_url: self.client_url(),

--- a/rusaint/src/application/personal_course_schedule/mod.rs
+++ b/rusaint/src/application/personal_course_schedule/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     model::SemesterType,
     webdynpro::{
         client::body::Body,
-        command::element::selection::{ComboBoxSelectCommand, ReadComboBoxLSDataCommand},
+        command::element::selection::{ComboBoxLSDataCommand, ComboBoxSelectEventCommand},
         element::{complex::SapTable, selection::ComboBox},
         error::{ElementError, WebDynproError},
     },
@@ -62,14 +62,18 @@ impl<'a> PersonalCourseScheduleApplication {
     ) -> Result<(), WebDynproError> {
         let semester = Self::semester_to_key(semester);
         let parser = ElementParser::new(self.body());
-        let year_combobox_lsdata = parser.read(ReadComboBoxLSDataCommand::new(Self::PERYR))?;
-        let semester_combobox_lsdata = parser.read(ReadComboBoxLSDataCommand::new(Self::PERID))?;
+        let year_combobox_lsdata = parser.read(ComboBoxLSDataCommand::new(Self::PERYR))?;
+        let semester_combobox_lsdata = parser.read(ComboBoxLSDataCommand::new(Self::PERID))?;
         if year_combobox_lsdata.key().map(String::as_str) != Some(year) {
-            let event = parser.read(ComboBoxSelectCommand::new(Self::PERYR, &year, false))?;
+            let event = parser.read(ComboBoxSelectEventCommand::new(Self::PERYR, &year, false))?;
             self.client.process_event(false, event).await?;
         }
         if semester_combobox_lsdata.key().map(String::as_str) != Some(semester) {
-            let event = parser.read(ComboBoxSelectCommand::new(Self::PERID, semester, false))?;
+            let event = parser.read(ComboBoxSelectEventCommand::new(
+                Self::PERID,
+                semester,
+                false,
+            ))?;
             self.client.process_event(false, event).await?;
         }
         Ok(())

--- a/rusaint/src/application/student_information/model/academic_record.rs
+++ b/rusaint/src/application/student_information/model/academic_record.rs
@@ -11,7 +11,7 @@ use crate::{
     application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
-        command::element::{complex::ReadSapTableBodyCommand, layout::TabStripTabSelectCommand},
+        command::element::{complex::SapTableBodyCommand, layout::TabStripTabSelectEventCommand},
         element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
@@ -39,7 +39,7 @@ impl<'a> StudentAcademicRecords {
 
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_READ_9600,
             5,
@@ -47,7 +47,7 @@ impl<'a> StudentAcademicRecords {
         ))?;
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::TABLE_9600))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_9600))?;
         let records = table.try_table_into::<StudentAcademicRecord>(&parser)?;
         Ok(Self { records })
     }

--- a/rusaint/src/application/student_information/model/bank_account.rs
+++ b/rusaint/src/application/student_information/model/bank_account.rs
@@ -5,8 +5,8 @@ use crate::{
     define_elements,
     webdynpro::{
         command::element::{
-            layout::TabStripTabSelectCommand, selection::ReadComboBoxValueCommand,
-            text::ReadInputFieldValueCommand,
+            layout::TabStripTabSelectEventCommand, selection::ComboBoxValueCommand,
+            text::InputFieldValueCommand,
         },
         element::{
             action::Button, layout::tab_strip::item::TabStripItem, selection::ComboBox,
@@ -44,7 +44,7 @@ impl<'a> StudentBankAccount {
 
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_BANK_CP,
             4,
@@ -54,14 +54,10 @@ impl<'a> StudentBankAccount {
         parser = ElementParser::new(client.body());
         Ok(Self {
             bank: parser
-                .read(ReadComboBoxValueCommand::new(Self::LIST_BANKS))
+                .read(ComboBoxValueCommand::new(Self::LIST_BANKS))
                 .ok(),
-            account_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::BANKN))
-                .ok(),
-            holder: parser
-                .read(ReadInputFieldValueCommand::new(Self::ZKOINH))
-                .ok(),
+            account_number: parser.read(InputFieldValueCommand::new(Self::BANKN)).ok(),
+            holder: parser.read(InputFieldValueCommand::new(Self::ZKOINH)).ok(),
         })
     }
 

--- a/rusaint/src/application/student_information/model/family.rs
+++ b/rusaint/src/application/student_information/model/family.rs
@@ -12,7 +12,7 @@ use crate::{
     define_elements,
     utils::de_with::{deserialize_bool_string, deserialize_optional_string},
     webdynpro::{
-        command::element::{complex::ReadSapTableBodyCommand, layout::TabStripTabSelectCommand},
+        command::element::{complex::SapTableBodyCommand, layout::TabStripTabSelectEventCommand},
         element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
@@ -40,7 +40,7 @@ impl<'a> StudentFamily {
 
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_FAMILY,
             1,
@@ -48,7 +48,7 @@ impl<'a> StudentFamily {
         ))?;
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::TABLE_FAMILY))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_FAMILY))?;
         let members = table.try_table_into::<StudentFamilyMember>(&parser)?;
         Ok(Self { members })
     }

--- a/rusaint/src/application/student_information/model/mod.rs
+++ b/rusaint/src/application/student_information/model/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     define_elements,
     webdynpro::{
-        command::element::text::ReadInputFieldValueCommand,
+        command::element::text::InputFieldValueCommand,
         element::{action::Button, graphic::Image, text::InputField},
         error::WebDynproError,
     },
@@ -126,60 +126,52 @@ impl<'a> StudentInformation {
             student_number: parser
                 .element_from_def(&Self::STUDENT12)?
                 .value_into_u32()?,
-            name: parser.read(ReadInputFieldValueCommand::new(Self::VORNA))?,
+            name: parser.read(InputFieldValueCommand::new(Self::VORNA))?,
             rrn: parser.element_from_def(&Self::PRDNI)?.value_into_u32()?,
-            collage: parser.read(ReadInputFieldValueCommand::new(Self::COLEG_TXT))?,
-            department: parser.read(ReadInputFieldValueCommand::new(Self::DEPT_TXT))?,
+            collage: parser.read(InputFieldValueCommand::new(Self::COLEG_TXT))?,
+            department: parser.read(InputFieldValueCommand::new(Self::DEPT_TXT))?,
             major: parser
-                .read(ReadInputFieldValueCommand::new(Self::MAJOR_TXT))
+                .read(InputFieldValueCommand::new(Self::MAJOR_TXT))
                 .ok(),
-            division: parser
-                .read(ReadInputFieldValueCommand::new(Self::TITEL))
-                .ok(),
+            division: parser.read(InputFieldValueCommand::new(Self::TITEL)).ok(),
             grade: parser.element_from_def(&Self::CMSTYEAR)?.value_into_u32()?,
             term: parser.element_from_def(&Self::ZSCHTERM)?.value_into_u32()?,
             image: Vec::with_capacity(0), // TODO: Image to bytes
-            alias: parser
-                .read(ReadInputFieldValueCommand::new(Self::RUFNM))
-                .ok(),
+            alias: parser.read(InputFieldValueCommand::new(Self::RUFNM)).ok(),
             kanji_name: parser
-                .read(ReadInputFieldValueCommand::new(Self::BIRTHNAME))
+                .read(InputFieldValueCommand::new(Self::BIRTHNAME))
                 .ok(),
             email: parser
-                .read(ReadInputFieldValueCommand::new(Self::SMTP_ADDR))
+                .read(InputFieldValueCommand::new(Self::SMTP_ADDR))
                 .ok(),
             tel_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::TEL_NUMBER))
+                .read(InputFieldValueCommand::new(Self::TEL_NUMBER))
                 .ok(),
             mobile_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::MOB_NUMBER))
+                .read(InputFieldValueCommand::new(Self::MOB_NUMBER))
                 .ok(),
             post_code: parser
-                .read(ReadInputFieldValueCommand::new(Self::POST_CODE))
+                .read(InputFieldValueCommand::new(Self::POST_CODE))
                 .ok(),
-            address: parser
-                .read(ReadInputFieldValueCommand::new(Self::CITY1))
-                .ok(),
-            specific_address: parser
-                .read(ReadInputFieldValueCommand::new(Self::STREET))
-                .ok(),
+            address: parser.read(InputFieldValueCommand::new(Self::CITY1)).ok(),
+            specific_address: parser.read(InputFieldValueCommand::new(Self::STREET)).ok(),
             is_transfer_student: !parser
-                .read(ReadInputFieldValueCommand::new(Self::NEWINCOR_CDT))?
+                .read(InputFieldValueCommand::new(Self::NEWINCOR_CDT))?
                 .contains("신입학"),
-            apply_date: parser.read(ReadInputFieldValueCommand::new(Self::APPLY_DT))?,
-            applied_collage: parser.read(ReadInputFieldValueCommand::new(Self::COLEG_CDT))?,
-            applied_department: parser.read(ReadInputFieldValueCommand::new(Self::DEPT_CDT))?,
+            apply_date: parser.read(InputFieldValueCommand::new(Self::APPLY_DT))?,
+            applied_collage: parser.read(InputFieldValueCommand::new(Self::COLEG_CDT))?,
+            applied_department: parser.read(InputFieldValueCommand::new(Self::DEPT_CDT))?,
             plural_major: parser
-                .read(ReadInputFieldValueCommand::new(Self::CG_STEXT1))
+                .read(InputFieldValueCommand::new(Self::CG_STEXT1))
                 .ok(),
             sub_major: parser
-                .read(ReadInputFieldValueCommand::new(Self::CG_STEXT2))
+                .read(InputFieldValueCommand::new(Self::CG_STEXT2))
                 .ok(),
             connected_major: parser
-                .read(ReadInputFieldValueCommand::new(Self::CG_STEXT3))
+                .read(InputFieldValueCommand::new(Self::CG_STEXT3))
                 .ok(),
             abeek: parser
-                .read(ReadInputFieldValueCommand::new(Self::CG_STEXT4))
+                .read(InputFieldValueCommand::new(Self::CG_STEXT4))
                 .ok(),
         })
     }

--- a/rusaint/src/application/student_information/model/qualification.rs
+++ b/rusaint/src/application/student_information/model/qualification.rs
@@ -3,7 +3,7 @@ use crate::webdynpro::element::parser::ElementParser;
 use crate::{
     define_elements,
     webdynpro::{
-        command::element::text::ReadInputFieldValueCommand, element::text::InputField,
+        command::element::text::InputFieldValueCommand, element::text::InputField,
         error::WebDynproError,
     },
 };
@@ -77,16 +77,16 @@ impl<'a> StudentTeachingMajorInformation {
     ) -> Result<StudentTeachingMajorInformation, WebDynproError> {
         Ok(Self {
             major_name: parser
-                .read(ReadInputFieldValueCommand::new(Self::MAJOR_OTYPE))
+                .read(InputFieldValueCommand::new(Self::MAJOR_OTYPE))
                 .ok(),
             qualification_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::MAJOR_QUAL_NUM))
+                .read(InputFieldValueCommand::new(Self::MAJOR_QUAL_NUM))
                 .ok(),
             initiation_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::MAJOR_SELECT_DT))
+                .read(InputFieldValueCommand::new(Self::MAJOR_SELECT_DT))
                 .ok(),
             qualification_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::MAJOR_QUAL_DT))
+                .read(InputFieldValueCommand::new(Self::MAJOR_QUAL_DT))
                 .ok(),
         })
     }
@@ -137,13 +137,13 @@ impl<'a> StudentTeachingPluralMajorInformation {
     ) -> Result<StudentTeachingPluralMajorInformation, WebDynproError> {
         Ok(Self {
             major_name: parser
-                .read(ReadInputFieldValueCommand::new(Self::DOUBLE_OTYPE))
+                .read(InputFieldValueCommand::new(Self::DOUBLE_OTYPE))
                 .ok(),
             qualification_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::DOUBLE_QUAL_NUM))
+                .read(InputFieldValueCommand::new(Self::DOUBLE_QUAL_NUM))
                 .ok(),
             qualification_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::DOUBLEL_DT))
+                .read(InputFieldValueCommand::new(Self::DOUBLEL_DT))
                 .ok(),
         })
     }
@@ -192,16 +192,16 @@ impl<'a> StudentLifelongInformation {
     ) -> Result<StudentLifelongInformation, WebDynproError> {
         Ok(Self {
             apply_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::CONEDU_APP_DT))
+                .read(InputFieldValueCommand::new(Self::CONEDU_APP_DT))
                 .ok(),
             lifelong_type: parser
-                .read(ReadInputFieldValueCommand::new(Self::CONEDU_TYPE))
+                .read(InputFieldValueCommand::new(Self::CONEDU_TYPE))
                 .ok(),
             qualification_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::CONEDU_QUAL_NUM))
+                .read(InputFieldValueCommand::new(Self::CONEDU_QUAL_NUM))
                 .ok(),
             qualification_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::CONEDU_QUAL_DT))
+                .read(InputFieldValueCommand::new(Self::CONEDU_QUAL_DT))
                 .ok(),
         })
     }
@@ -252,13 +252,13 @@ impl<'a> StudentForignStudyInformation {
     ) -> Result<StudentForignStudyInformation, WebDynproError> {
         Ok(Self {
             approval_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::APPRODATE))
+                .read(InputFieldValueCommand::new(Self::APPRODATE))
                 .ok(),
             authentication_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::AUTHEN_NO))
+                .read(InputFieldValueCommand::new(Self::AUTHEN_NO))
                 .ok(),
             issue_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::ISSUEDATE))
+                .read(InputFieldValueCommand::new(Self::ISSUEDATE))
                 .ok(),
         })
     }

--- a/rusaint/src/application/student_information/model/religion.rs
+++ b/rusaint/src/application/student_information/model/religion.rs
@@ -5,8 +5,8 @@ use crate::{
     define_elements,
     webdynpro::{
         command::element::{
-            layout::TabStripTabSelectCommand, selection::ReadComboBoxValueCommand,
-            text::ReadInputFieldValueCommand,
+            layout::TabStripTabSelectEventCommand, selection::ComboBoxValueCommand,
+            text::InputFieldValueCommand,
         },
         element::{
             action::Button, layout::tab_strip::item::TabStripItem, selection::ComboBox,
@@ -77,7 +77,7 @@ impl<'a> StudentReligion {
 
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_RELIGION,
             2,
@@ -87,46 +87,46 @@ impl<'a> StudentReligion {
         parser = ElementParser::new(client.body());
         Ok(Self {
             religion_type: parser
-                .read(ReadComboBoxValueCommand::new(Self::RELIGION_COD))
+                .read(ComboBoxValueCommand::new(Self::RELIGION_COD))
                 .ok(),
             start_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::BELIEF_START_DATE))
+                .read(InputFieldValueCommand::new(Self::BELIEF_START_DATE))
                 .ok(),
             church: parser
-                .read(ReadInputFieldValueCommand::new(Self::PRES_CHURCH))
+                .read(InputFieldValueCommand::new(Self::PRES_CHURCH))
                 .ok(),
             church_man: parser
-                .read(ReadInputFieldValueCommand::new(Self::CHURCH_MAN))
+                .read(InputFieldValueCommand::new(Self::CHURCH_MAN))
                 .ok(),
             baptism_level: parser
-                .read(ReadComboBoxValueCommand::new(Self::BAPTISM_LVL))
+                .read(ComboBoxValueCommand::new(Self::BAPTISM_LVL))
                 .ok(),
             baptism_grp: parser
-                .read(ReadInputFieldValueCommand::new(Self::BAPTISM_GRP))
+                .read(InputFieldValueCommand::new(Self::BAPTISM_GRP))
                 .ok(),
             service_department: parser
-                .read(ReadInputFieldValueCommand::new(Self::SERVICE_DEPT_DES))
+                .read(InputFieldValueCommand::new(Self::SERVICE_DEPT_DES))
                 .ok(),
             service_department_title: parser
-                .read(ReadInputFieldValueCommand::new(Self::SERVICE_DEPT_LVL))
+                .read(InputFieldValueCommand::new(Self::SERVICE_DEPT_LVL))
                 .ok(),
             church_address: parser
-                .read(ReadInputFieldValueCommand::new(Self::CHURCH_ADDR))
+                .read(InputFieldValueCommand::new(Self::CHURCH_ADDR))
                 .ok(),
             singeub: parser
-                .read(ReadComboBoxValueCommand::new(Self::SINGEUB_DES))
+                .read(ComboBoxValueCommand::new(Self::SINGEUB_DES))
                 .ok(),
             baptism_date: parser
-                .read(ReadInputFieldValueCommand::new(Self::BAPTISM_DT))
+                .read(InputFieldValueCommand::new(Self::BAPTISM_DT))
                 .ok(),
             baptism_church: parser
-                .read(ReadInputFieldValueCommand::new(Self::BAPTISM_CH))
+                .read(InputFieldValueCommand::new(Self::BAPTISM_CH))
                 .ok(),
             baptism_man: parser
-                .read(ReadInputFieldValueCommand::new(Self::BAPTISM_MAN))
+                .read(InputFieldValueCommand::new(Self::BAPTISM_MAN))
                 .ok(),
             church_grp: parser
-                .read(ReadInputFieldValueCommand::new(Self::CHURCH_GRP))
+                .read(InputFieldValueCommand::new(Self::CHURCH_GRP))
                 .ok(),
         })
     }

--- a/rusaint/src/application/student_information/model/research_bank_account.rs
+++ b/rusaint/src/application/student_information/model/research_bank_account.rs
@@ -5,8 +5,8 @@ use crate::{
     define_elements,
     webdynpro::{
         command::element::{
-            layout::TabStripTabSelectCommand, selection::ReadComboBoxValueCommand,
-            text::ReadInputFieldValueCommand,
+            layout::TabStripTabSelectEventCommand, selection::ComboBoxValueCommand,
+            text::InputFieldValueCommand,
         },
         element::{
             action::Button, layout::tab_strip::item::TabStripItem, selection::ComboBox,
@@ -44,7 +44,7 @@ impl<'a> StudentResearchBankAccount {
 
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_RES_ACCOUNT,
             6,
@@ -53,14 +53,12 @@ impl<'a> StudentResearchBankAccount {
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
         Ok(Self {
-            bank: parser
-                .read(ReadComboBoxValueCommand::new(Self::BANK_TEXT))
-                .ok(),
+            bank: parser.read(ComboBoxValueCommand::new(Self::BANK_TEXT)).ok(),
             account_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::BANKN_TEXT))
+                .read(InputFieldValueCommand::new(Self::BANKN_TEXT))
                 .ok(),
             holder: parser
-                .read(ReadInputFieldValueCommand::new(Self::ZKOINH_TEXT))
+                .read(InputFieldValueCommand::new(Self::ZKOINH_TEXT))
                 .ok(),
         })
     }

--- a/rusaint/src/application/student_information/model/transfer.rs
+++ b/rusaint/src/application/student_information/model/transfer.rs
@@ -11,7 +11,7 @@ use crate::{
     application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
-        command::element::{complex::ReadSapTableBodyCommand, layout::TabStripTabSelectCommand},
+        command::element::{complex::SapTableBodyCommand, layout::TabStripTabSelectEventCommand},
         element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
@@ -39,7 +39,7 @@ impl<'a> StudentTransferRecords {
 
     pub(crate) async fn with_client(client: &mut USaintClient) -> Result<Self, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_TRANSFER,
             3,
@@ -47,7 +47,7 @@ impl<'a> StudentTransferRecords {
         ))?;
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
-        let table = parser.read(ReadSapTableBodyCommand::new(Self::TABLE_TRANSFER))?;
+        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_TRANSFER))?;
         let records = table.try_table_into::<StudentTransferRecord>(&parser)?;
         Ok(Self { records })
     }

--- a/rusaint/src/application/student_information/model/work.rs
+++ b/rusaint/src/application/student_information/model/work.rs
@@ -5,8 +5,8 @@ use crate::{
     define_elements,
     webdynpro::{
         command::element::{
-            layout::TabStripTabSelectCommand, selection::ReadComboBoxValueCommand,
-            text::ReadInputFieldValueCommand,
+            layout::TabStripTabSelectEventCommand, selection::ComboBoxValueCommand,
+            text::InputFieldValueCommand,
         },
         element::{
             action::Button, layout::tab_strip::item::TabStripItem, selection::ComboBox,
@@ -67,7 +67,7 @@ impl<'a> StudentWorkInformation {
         client: &mut USaintClient,
     ) -> Result<StudentWorkInformation, WebDynproError> {
         let mut parser = ElementParser::new(client.body());
-        let event = parser.read(TabStripTabSelectCommand::new(
+        let event = parser.read(TabStripTabSelectEventCommand::new(
             StudentInformationApplication::TAB_ADDITION,
             Self::TAB_WORK,
             0,
@@ -76,33 +76,33 @@ impl<'a> StudentWorkInformation {
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
         Ok(Self {
-            job: parser.read(ReadComboBoxValueCommand::new(Self::COJOB)).ok(),
+            job: parser.read(ComboBoxValueCommand::new(Self::COJOB)).ok(),
             public_official: parser
-                .read(ReadComboBoxValueCommand::new(Self::COMPANY_ORGR))
+                .read(ComboBoxValueCommand::new(Self::COMPANY_ORGR))
                 .ok(),
             company_name: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_NAM))
+                .read(InputFieldValueCommand::new(Self::COMPANY_NAM))
                 .ok(),
             department_name: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_DEPT_NAM))
+                .read(InputFieldValueCommand::new(Self::COMPANY_DEPT_NAM))
                 .ok(),
             title: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_TITLE))
+                .read(InputFieldValueCommand::new(Self::COMPANY_TITLE))
                 .ok(),
             zip_code: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_ZIP_COD))
+                .read(InputFieldValueCommand::new(Self::COMPANY_ZIP_COD))
                 .ok(),
             address: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_ADDRESS))
+                .read(InputFieldValueCommand::new(Self::COMPANY_ADDRESS))
                 .ok(),
             specific_address: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_ADDRESS2))
+                .read(InputFieldValueCommand::new(Self::COMPANY_ADDRESS2))
                 .ok(),
             tel_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_TEL1))
+                .read(InputFieldValueCommand::new(Self::COMPANY_TEL1))
                 .ok(),
             fax_number: parser
-                .read(ReadInputFieldValueCommand::new(Self::COMPANY_TEL2))
+                .read(InputFieldValueCommand::new(Self::COMPANY_TEL2))
                 .ok(),
         })
     }

--- a/rusaint/src/webdynpro/command/element/action.rs
+++ b/rusaint/src/webdynpro/command/element/action.rs
@@ -4,19 +4,19 @@ use crate::webdynpro::{
     command::WebDynproCommand, element::action::ButtonDef, error::WebDynproError,
 };
 
-/// 주어진 [`Button`](crate::webdynpro::element::action::Button)을 누름
-pub struct ButtonPressCommand {
+/// 주어진 [`Button`](crate::webdynpro::element::action::Button)을 누르는 이벤트를 반환
+pub struct ButtonPressEventCommand {
     element_def: ButtonDef,
 }
 
-impl ButtonPressCommand {
+impl ButtonPressEventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(element_def: ButtonDef) -> Self {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ButtonPressCommand {
+impl WebDynproCommand for ButtonPressEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {

--- a/rusaint/src/webdynpro/command/element/complex.rs
+++ b/rusaint/src/webdynpro/command/element/complex.rs
@@ -9,8 +9,8 @@ use crate::webdynpro::{
     error::WebDynproError,
 };
 
-/// 주어진 [`SapTable`](crate::webdynpro::element::complex::SapTable)의 상하 스크롤을 수행
-pub struct SapTableVerticalScrollCommand {
+/// 주어진 [`SapTable`](crate::webdynpro::element::complex::SapTable)의 상하 스크롤을 수행하는 이벤트를 반환
+pub struct SapTableVerticalScrollEventCommand {
     element_def: SapTableDef,
     first_visible_item_index: u32,
     cell_id: String,
@@ -21,7 +21,7 @@ pub struct SapTableVerticalScrollCommand {
     alt: bool,
 }
 
-impl SapTableVerticalScrollCommand {
+impl SapTableVerticalScrollEventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(
         element_def: SapTableDef,
@@ -46,7 +46,7 @@ impl SapTableVerticalScrollCommand {
     }
 }
 
-impl WebDynproCommand for SapTableVerticalScrollCommand {
+impl WebDynproCommand for SapTableVerticalScrollEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -63,18 +63,18 @@ impl WebDynproCommand for SapTableVerticalScrollCommand {
 }
 
 /// [`SapTableLSData`]를 반환
-pub struct ReadSapTableLSDataCommand {
+pub struct SapTableLSDataCommand {
     element_def: SapTableDef,
 }
 
-impl ReadSapTableLSDataCommand {
+impl SapTableLSDataCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: SapTableDef) -> ReadSapTableLSDataCommand {
+    pub fn new(element_def: SapTableDef) -> SapTableLSDataCommand {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadSapTableLSDataCommand {
+impl WebDynproCommand for SapTableLSDataCommand {
     type Result = SapTableLSData;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -84,18 +84,18 @@ impl WebDynproCommand for ReadSapTableLSDataCommand {
 }
 
 /// [`SapTableBody`]를 반환
-pub struct ReadSapTableBodyCommand {
+pub struct SapTableBodyCommand {
     element_def: SapTableDef,
 }
 
-impl ReadSapTableBodyCommand {
+impl SapTableBodyCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: SapTableDef) -> ReadSapTableBodyCommand {
+    pub fn new(element_def: SapTableDef) -> SapTableBodyCommand {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadSapTableBodyCommand {
+impl WebDynproCommand for SapTableBodyCommand {
     type Result = SapTableBody;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {

--- a/rusaint/src/webdynpro/command/element/layout.rs
+++ b/rusaint/src/webdynpro/command/element/layout.rs
@@ -9,22 +9,22 @@ use crate::webdynpro::{
     error::WebDynproError,
 };
 
-/// [`TabStrip`](crate::webdynpro::element::layout::TabStrip)의 탭을 선택하도록 함
-pub struct TabStripTabSelectCommand {
+/// [`TabStrip`](crate::webdynpro::element::layout::TabStrip)의 탭을 선택하도록 하는 이벤트를 반환
+pub struct TabStripTabSelectEventCommand {
     element_def: TabStripDef,
     item_id: String,
     item_index: u32,
     first_visible_item_index: u32,
 }
 
-impl<'a> TabStripTabSelectCommand {
+impl<'a> TabStripTabSelectEventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(
         element_def: TabStripDef,
         item: TabStripItemDef,
         item_index: u32,
         first_visible_item_index: u32,
-    ) -> TabStripTabSelectCommand {
+    ) -> TabStripTabSelectEventCommand {
         Self {
             element_def,
             item_id: item.id().to_owned(),
@@ -34,7 +34,7 @@ impl<'a> TabStripTabSelectCommand {
     }
 }
 
-impl WebDynproCommand for TabStripTabSelectCommand {
+impl WebDynproCommand for TabStripTabSelectEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {

--- a/rusaint/src/webdynpro/command/element/selection.rs
+++ b/rusaint/src/webdynpro/command/element/selection.rs
@@ -14,16 +14,16 @@ use crate::webdynpro::{
     error::{ElementError, WebDynproError},
 };
 
-/// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 선택지를 선택하도록 함
-pub struct ComboBoxSelectCommand {
+/// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 선택지를 선택하도록 하는 이벤트를 반환
+pub struct ComboBoxSelectEventCommand {
     element_def: ComboBoxDef,
     key: String,
     by_enter: bool,
 }
 
-impl ComboBoxSelectCommand {
+impl ComboBoxSelectEventCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: ComboBoxDef, key: &str, by_enter: bool) -> ComboBoxSelectCommand {
+    pub fn new(element_def: ComboBoxDef, key: &str, by_enter: bool) -> ComboBoxSelectEventCommand {
         Self {
             element_def,
             key: key.to_string(),
@@ -32,7 +32,7 @@ impl ComboBoxSelectCommand {
     }
 }
 
-impl WebDynproCommand for ComboBoxSelectCommand {
+impl WebDynproCommand for ComboBoxSelectEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -42,17 +42,21 @@ impl WebDynproCommand for ComboBoxSelectCommand {
     }
 }
 
-/// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 내용을 바꿈
+/// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 내용을 바꾸는 이벤트를 반환
 #[allow(unused)]
-pub struct ComboBoxChangeCommand {
+pub struct ComboBoxChangeEventCommand {
     element_def: ComboBoxDef,
     value: String,
     by_enter: bool,
 }
 
-impl ComboBoxChangeCommand {
+impl ComboBoxChangeEventCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: ComboBoxDef, value: &str, by_enter: bool) -> ComboBoxChangeCommand {
+    pub fn new(
+        element_def: ComboBoxDef,
+        value: &str,
+        by_enter: bool,
+    ) -> ComboBoxChangeEventCommand {
         Self {
             element_def,
             value: value.to_string(),
@@ -61,7 +65,7 @@ impl ComboBoxChangeCommand {
     }
 }
 
-impl WebDynproCommand for ComboBoxChangeCommand {
+impl WebDynproCommand for ComboBoxChangeEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -71,21 +75,21 @@ impl WebDynproCommand for ComboBoxChangeCommand {
     }
 }
 
-/// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 선택지를 `value1`의 값을 기반으로 선택하도록 함
+/// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 선택지를 `value1`의 값을 기반으로 선택하도록 하는 이벤트를 반환
 #[allow(unused)]
-pub struct ComboBoxSelectByValue1Command {
+pub struct ComboBoxSelectByValue1EventCommand {
     element_def: ComboBoxDef,
     value: String,
     by_enter: bool,
 }
 
-impl ComboBoxSelectByValue1Command {
+impl ComboBoxSelectByValue1EventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(
         element_def: ComboBoxDef,
         value: &str,
         by_enter: bool,
-    ) -> ComboBoxSelectByValue1Command {
+    ) -> ComboBoxSelectByValue1EventCommand {
         Self {
             element_def,
             value: value.to_string(),
@@ -94,14 +98,12 @@ impl ComboBoxSelectByValue1Command {
     }
 }
 
-impl WebDynproCommand for ComboBoxSelectByValue1Command {
+impl WebDynproCommand for ComboBoxSelectByValue1EventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
-        let listbox_def = parser.read(ReadComboBoxItemListBoxCommand::new(
-            self.element_def.clone(),
-        ))?;
-        let items = parser.read(ReadListBoxItemInfoCommand::new(listbox_def))?;
+        let listbox_def = parser.read(ComboBoxItemListBoxCommand::new(self.element_def.clone()))?;
+        let items = parser.read(ListBoxItemInfoCommand::new(listbox_def))?;
         let item_key = items
             .iter()
             .find_map(|info| match info {
@@ -119,7 +121,7 @@ impl WebDynproCommand for ComboBoxSelectByValue1Command {
                 content: format!("Cannot find {} option", self.value),
             })?
             .to_owned();
-        parser.read(ComboBoxSelectCommand::new(
+        parser.read(ComboBoxSelectEventCommand::new(
             self.element_def.clone(),
             &item_key,
             false,
@@ -128,18 +130,18 @@ impl WebDynproCommand for ComboBoxSelectByValue1Command {
 }
 
 /// [`ComboBoxLSData`]를 반환
-pub struct ReadComboBoxLSDataCommand {
+pub struct ComboBoxLSDataCommand {
     element_def: ComboBoxDef,
 }
 
-impl ReadComboBoxLSDataCommand {
+impl ComboBoxLSDataCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: ComboBoxDef) -> ReadComboBoxLSDataCommand {
+    pub fn new(element_def: ComboBoxDef) -> ComboBoxLSDataCommand {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadComboBoxLSDataCommand {
+impl WebDynproCommand for ComboBoxLSDataCommand {
     type Result = ComboBoxLSData;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -149,18 +151,18 @@ impl WebDynproCommand for ReadComboBoxLSDataCommand {
 }
 
 /// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 참조 [`ListBoxDefWrapper`]를 반환
-pub struct ReadComboBoxItemListBoxCommand {
+pub struct ComboBoxItemListBoxCommand {
     element_def: ComboBoxDef,
 }
 
-impl ReadComboBoxItemListBoxCommand {
+impl ComboBoxItemListBoxCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: ComboBoxDef) -> ReadComboBoxItemListBoxCommand {
+    pub fn new(element_def: ComboBoxDef) -> ComboBoxItemListBoxCommand {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadComboBoxItemListBoxCommand {
+impl WebDynproCommand for ComboBoxItemListBoxCommand {
     type Result = ListBoxDefWrapper;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -172,18 +174,18 @@ impl WebDynproCommand for ReadComboBoxItemListBoxCommand {
 }
 
 /// [`ComboBox`](crate::webdynpro::element::selection::ComboBox)의 값을 반환
-pub struct ReadComboBoxValueCommand {
+pub struct ComboBoxValueCommand {
     element_def: ComboBoxDef,
 }
 
-impl ReadComboBoxValueCommand {
+impl ComboBoxValueCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(element_def: ComboBoxDef) -> Self {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadComboBoxValueCommand {
+impl WebDynproCommand for ComboBoxValueCommand {
     type Result = String;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -200,18 +202,18 @@ impl WebDynproCommand for ReadComboBoxValueCommand {
 }
 
 /// [`ListBox`](crate::webdynpro::element::selection::list_box::ListBox)의 아이템 정보를 가져옴
-pub struct ReadListBoxItemInfoCommand {
+pub struct ListBoxItemInfoCommand {
     element_def: ListBoxDefWrapper,
 }
 
-impl ReadListBoxItemInfoCommand {
+impl ListBoxItemInfoCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(element_def: ListBoxDefWrapper) -> Self {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadListBoxItemInfoCommand {
+impl WebDynproCommand for ListBoxItemInfoCommand {
     type Result = Vec<ListBoxItemInfo>;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {

--- a/rusaint/src/webdynpro/command/element/system.rs
+++ b/rusaint/src/webdynpro/command/element/system.rs
@@ -6,13 +6,13 @@ use crate::webdynpro::{
     error::WebDynproError,
 };
 
-/// [`ClientInspector`](crate::webdynpro::element::system::ClientInspector)를 통해 서버에 클라이언트 정보를 전파합니다.
-pub struct ClientInspectorNotifyCommand {
+/// [`ClientInspector`](crate::webdynpro::element::system::ClientInspector)를 통해 서버에 클라이언트 정보를 전파하는 이벤트를 반환
+pub struct ClientInspectorNotifyEventCommand {
     element_def: ClientInspectorDef,
     message: String,
 }
 
-impl ClientInspectorNotifyCommand {
+impl ClientInspectorNotifyEventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(element_def: ClientInspectorDef, message: &str) -> Self {
         Self {
@@ -22,7 +22,7 @@ impl ClientInspectorNotifyCommand {
     }
 }
 
-impl WebDynproCommand for ClientInspectorNotifyCommand {
+impl WebDynproCommand for ClientInspectorNotifyEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -32,19 +32,19 @@ impl WebDynproCommand for ClientInspectorNotifyCommand {
     }
 }
 
-/// [`LoadingPlaceholder`](crate::webdynpro::element::system::LoadingPlaceholder)를 로드합니다.
-pub struct LoadingPlaceholderLoadCommand {
+/// [`LoadingPlaceholder`](crate::webdynpro::element::system::LoadingPlaceholder)를 로드하는 이벤트를 반환
+pub struct LoadingPlaceholderLoadEventCommand {
     element_def: LoadingPlaceholderDef,
 }
 
-impl LoadingPlaceholderLoadCommand {
+impl LoadingPlaceholderLoadEventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(element_def: LoadingPlaceholderDef) -> Self {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for LoadingPlaceholderLoadCommand {
+impl WebDynproCommand for LoadingPlaceholderLoadEventCommand {
     type Result = Event;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {
@@ -52,20 +52,20 @@ impl WebDynproCommand for LoadingPlaceholderLoadCommand {
     }
 }
 
-/// ClientInfo 명령을 커스텀 객체를 이용해 서버에 전송합니다.
-pub struct CustomClientInfoCommand {
+/// ClientInfo 명령을 커스텀 객체를 이용해 서버에 전송하는 이벤트를 반환
+pub struct CustomClientInfoEventCommand {
     element: Custom,
     info: CustomClientInfo,
 }
 
-impl CustomClientInfoCommand {
+impl CustomClientInfoEventCommand {
     /// 새로운 명령 객체를 생성합니다.
     pub fn new(element: Custom, info: CustomClientInfo) -> Self {
         Self { element, info }
     }
 }
 
-impl WebDynproCommand for CustomClientInfoCommand {
+impl WebDynproCommand for CustomClientInfoEventCommand {
     type Result = Event;
 
     fn dispatch(&self, _parser: &ElementParser) -> Result<Self::Result, WebDynproError> {

--- a/rusaint/src/webdynpro/command/element/text.rs
+++ b/rusaint/src/webdynpro/command/element/text.rs
@@ -6,18 +6,18 @@ use crate::webdynpro::{
 };
 
 /// [`InputField`](crate::webdynpro::element::text::InputField)의 값을 반환
-pub struct ReadInputFieldValueCommand {
+pub struct InputFieldValueCommand {
     element_def: InputFieldDef,
 }
 
-impl ReadInputFieldValueCommand {
+impl InputFieldValueCommand {
     /// 새로운 명령 객체를 생성합니다.
-    pub fn new(element_def: InputFieldDef) -> ReadInputFieldValueCommand {
+    pub fn new(element_def: InputFieldDef) -> InputFieldValueCommand {
         Self { element_def }
     }
 }
 
-impl WebDynproCommand for ReadInputFieldValueCommand {
+impl WebDynproCommand for InputFieldValueCommand {
     type Result = String;
 
     fn dispatch(&self, parser: &ElementParser) -> Result<Self::Result, WebDynproError> {


### PR DESCRIPTION
# What's in this pull request
- `WebDynproCommand`들의 명명 방식을 변경했습니다(참고: #69).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced event handling through the renaming of command structures to reflect an event-driven architecture, improving clarity and maintainability.
  
- **Bug Fixes**
	- Updated command names to ensure consistency across various modules, enhancing the overall functionality and responsiveness of user interactions.

- **Refactor**
	- Streamlined command structures by renaming several commands to better represent their purpose, such as changing `ReadInputFieldValueCommand` to `InputFieldValueCommand`.

- **Documentation**
	- Updated documentation comments to clarify the new event-oriented functionality of commands, aiding developer understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->