### PR TITLE
[feat] `rust-android-gradle`을 이용한 Android 빌드 통합

### DIFF
--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -1,7 +1,9 @@
 # Android
+
 rusaint library for Android
 
 ## Prerequisites
+
 - Basic build tools for Android(`gradle`... etc.)
 - Android NDK
 - [Rust](https://www.rust-lang.org/tools/install) toolchain

--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -1,23 +1,22 @@
-Created with reference to https://github.com/bitwarden/sdk/blob/main/languages/kotlin/README.md
-
 # Android
+rusaint library for Android
+
+## Prerequisites
+- Basic build tools for Android(`gradle`... etc.)
+- Android NDK
+- [Rust](https://www.rust-lang.org/tools/install) toolchain
+- Install `rustup` targets: see below for instructions
 
 ```bash
-cargo install cross --locked --git https://github.com/cross-rs/cross.git --rev 185398b1b885820515a212de720a306b08e2c8c9
+rustup target add armv7-linux-androideabi   # for arm
+rustup target add i686-linux-android        # for x86
+rustup target add aarch64-linux-android     # for arm64
+rustup target add x86_64-linux-android      # for x86_64
 ```
 
-## building
+## Building
 
 ```bash
-mkdir -p ./lib/src/main/jniLibs/{arm64-v8a,x86_64}
-
-cross build -p rusaint-ffi --release --target=aarch64-linux-android
-mv ../../target/aarch64-linux-android/release/librusaint_ffi.so ./lib/src/main/jniLibs/arm64-v8a/librusaint_ffi.so
-
-cross build -p rusaint-ffi --release --target=x86_64-linux-android
-mv ../../target/x86_64-linux-android/release/librusaint_ffi.so ./lib/src/main/jniLibs/x86_64/librusaint_ffi.so
-```
-
-```bash
-./build-bindings.sh
+# Make sure rust toolchain and android targets are installed
+./gradlew build
 ```

--- a/languages/kotlin/build-bindings.sh
+++ b/languages/kotlin/build-bindings.sh
@@ -1,6 +1,0 @@
-cargo run -p uniffi-bindgen generate \
-  ./lib/src/main/jniLibs/arm64-v8a/librusaint_ffi.so \
-  --library \
-  --language kotlin \
-  --no-format \
-  --out-dir lib/src/main/kotlin

--- a/languages/kotlin/build.gradle.kts
+++ b/languages/kotlin/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.rust.android) apply false
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false

--- a/languages/kotlin/gradle/libs.versions.toml
+++ b/languages/kotlin/gradle/libs.versions.toml
@@ -5,17 +5,19 @@
 commons-math3 = "3.6.1"
 guava = "33.2.1-jre"
 junit-jupiter-engine = "5.10.3"
-agp = "8.2.0"
+agp = "8.2.2"
 kotlin = "1.9.23"
 core-ktx = "1.13.1"
 junit = "4.13.2"
 junit-version = "1.2.1"
 espresso-core = "3.6.1"
-lifecycle-runtime-ktx = "2.8.3"
-activity-compose = "1.9.0"
-compose-bom = "2024.04.01"
+kotlinx-coroutines-android = "1.7.3"
+lifecycle-runtime-ktx = "2.8.6"
+activity-compose = "1.9.3"
+compose-bom = "2024.10.00"
 appcompat = "1.7.0"
 material = "1.12.0"
+rust-android = "0.9.4"
 
 [libraries]
 commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }
@@ -25,6 +27,7 @@ core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit-version" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines-android" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -44,3 +47,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rust-android"}

--- a/languages/kotlin/lib/build.gradle.kts
+++ b/languages/kotlin/lib/build.gradle.kts
@@ -15,6 +15,8 @@ android {
     defaultConfig {
         minSdk = 24
 
+        version = "0.6.2"
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/languages/kotlin/lib/build.gradle.kts
+++ b/languages/kotlin/lib/build.gradle.kts
@@ -1,10 +1,14 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
+    alias(libs.plugins.rust.android)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
 }
 
 android {
     namespace = "dev.eatsteak.rusaint"
+    ndkVersion = "27.2.12479018"
     compileSdk = 34
 
     defaultConfig {
@@ -32,11 +36,35 @@ android {
     }
 }
 
-dependencies {
-    implementation("net.java.dev.jna:jna:5.14.0@aar")
-    implementation("androidx.core:core-ktx:1.13.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+cargo {
+    module = "../../.."
+    libname = "rusaint-ffi"
+    targets = listOf("arm", "x86", "arm64", "x86_64")
+    profile = "release"
+    targetIncludes = arrayOf("librusaint_ffi.so")
+}
 
+tasks.withType<KotlinCompile> {
+    dependsOn("generateBindings")
+}
+
+task<Exec>("generateBindings") {
+    dependsOn("cargoBuild")
+    commandLine("cargo", "run", "-p", "uniffi-bindgen", "generate",
+        "./build/rustJniLibs/android/arm64-v8a/librusaint_ffi.so",
+        "--library",
+        "--language",
+        "kotlin",
+        "--no-format",
+        "--out-dir",
+        "src/main/kotlin")
+}
+
+dependencies {
+    //noinspection UseTomlInstead
+    // See: https://github.com/gradle/gradle/issues/21267
+    implementation("net.java.dev.jna:jna:5.14.0@aar")
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.core.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)

--- a/languages/kotlin/lib/src/main/jniLibs/.gitignore
+++ b/languages/kotlin/lib/src/main/jniLibs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
# What's in this pull request
- `rust-android-gradle`을 사용하여 `:lib:build` 태스크 실행 시 rust 바이너리 빌드도 동시에 진행됩니다.
- 필요 없어진 `build-bindings.sh` 파일을 삭제했습니다.
- `generateBindings` task로 생성된 rust 바이너리로 바인딩 생성이 가능합니다.

## TODO
- `cargoBuild`에 `output`이 없습니다. incremental build를 위해 설정이 필요합니다.
- maven central 인증이 완료되면 publish task를 추가합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated prerequisites and building instructions for Kotlin projects.
	- Introduced a new task to generate bindings for Rust libraries.
- **Bug Fixes**
	- Removed outdated build commands for improved clarity.
- **Documentation**
	- Enhanced the README with updated prerequisites and installation instructions.
- **Chores**
	- Updated dependency versions for improved stability and performance.
	- Removed unnecessary files to streamline project structure.
	- Added Rust plugin integration for better project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->