### PR TITLE
[feat(kotlin)] Maven Central 배포

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release (Publish to Maven Central)
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: 'armv7-linux-androideabi, i686-linux-android, aarch64-linux-android, x86_64-linux-android'
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 23
+          distribution: temurin
+          cache: gradle
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Setup Android NDK
+        run: 'sdkmanager "ndk;27.2.12479018"'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Publish with Gradle
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+        run: |
+          cd ./languages/kotlin
+          chmod +x ./gradlew
+          ./gradlew publish
+          ./gradlew jreleaserFullRelease

--- a/languages/kotlin/build.gradle.kts
+++ b/languages/kotlin/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.jetbrains.kotlin.serialization) apply false
+    alias(libs.plugins.jreleaser) apply false
 }

--- a/languages/kotlin/gradle/libs.versions.toml
+++ b/languages/kotlin/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 commons-math3 = "3.6.1"
 guava = "33.2.1-jre"
 junit-jupiter-engine = "5.10.3"
-agp = "8.2.2"
+agp = "8.5.2"
 kotlin = "1.9.23"
 core-ktx = "1.13.1"
 junit = "4.13.2"
@@ -18,6 +18,7 @@ compose-bom = "2024.10.00"
 appcompat = "1.7.0"
 material = "1.12.0"
 rust-android = "0.9.4"
+jreleaser = "1.14.0"
 
 [libraries]
 commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }
@@ -48,3 +49,4 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rust-android"}
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }

--- a/languages/kotlin/lib/build.gradle.kts
+++ b/languages/kotlin/lib/build.gradle.kts
@@ -31,13 +31,7 @@ android {
     }
 
     buildTypes {
-        release {
-            isMinifyEnabled = true
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
+        getByName("release") {}
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/languages/kotlin/lib/build.gradle.kts
+++ b/languages/kotlin/lib/build.gradle.kts
@@ -1,21 +1,30 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jreleaser.model.Active
 import java.io.ByteArrayOutputStream
 
 plugins {
+    alias(libs.plugins.jreleaser)
     alias(libs.plugins.rust.android)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
+    `maven-publish`
 }
+
+group = "dev.eatsteak"
+description = "Easy and Reliable SSU u-saint scraper"
+version = "0.6.2"
 
 android {
     namespace = "dev.eatsteak.rusaint"
+
+    buildToolsVersion = "34.0.0"
     ndkVersion = "27.2.12479018"
     compileSdk = 34
 
     defaultConfig {
         minSdk = 24
 
-        version = "0.6.2"
+        version = project.version
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -23,7 +32,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -36,6 +45,12 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+
+    publishing {
+        singleVariant("release") {
+            withJavadocJar()
+        }
     }
 }
 
@@ -51,35 +66,30 @@ tasks.withType<KotlinCompile> {
     dependsOn("generateBindings")
 }
 
-task<Exec>("generateBindings") {
+tasks.register<Exec>("generateBindings") {
     dependsOn("cargoBuild")
-
-    inputs.files(fileTree("build/rustJniLibs"))
     outputs.dir("src/main/kotlin")
 
     doFirst {
         mkdir("src/main/kotlin")
     }
 
-    // Use the first available .so file from any architecture
-    val soFile = fileTree("build/rustJniLibs").matching {
-        include("**/librusaint_ffi.so")
-    }.firstOrNull() ?: throw GradleException("No .so file found")
-
-    commandLine("cargo", "run", "-p", "uniffi-bindgen", "generate",
-        soFile.absolutePath,
+    commandLine(
+        "cargo", "run", "-p", "uniffi-bindgen", "generate",
+        "./build/rustJniLibs/android/arm64-v8a/librusaint_ffi.so",
         "--library",
         "--language",
         "kotlin",
         "--no-format",
         "--out-dir",
-        "src/main/kotlin")
+        "src/main/kotlin"
+    )
 
     // Add error handling
     errorOutput = ByteArrayOutputStream()
     doLast {
         if (executionResult.get().exitValue != 0) {
-            throw GradleException("Failed to generate bindings: ${errorOutput}")
+            throw GradleException("Failed to generate bindings: $errorOutput")
         }
     }
 }
@@ -93,4 +103,89 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)
+}
+
+jreleaser {
+    gitRootSearch = true
+
+    project {
+        name = "rusaint"
+        copyright = "2024 EATSTEAK"
+        author("EATSTEAK")
+    }
+
+    release {
+        github {
+            repoOwner = "EATSTEAK"
+            name = "rusaint"
+            releaseName = "{{tagName}}"
+        }
+    }
+
+    signing {
+        active = Active.ALWAYS
+        armored = true
+        verify = true
+    }
+
+    deploy {
+        maven {
+            mavenCentral {
+                create("sonatype") {
+                    active = Active.ALWAYS
+                    url = "https://central.sonatype.com/api/v1/publisher"
+                    stagingRepository("build/staging-deploy")
+                    applyMavenCentralRules = false
+                    sign = true
+                    checksums = true
+                    javadocJar = true
+                }
+            }
+        }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
+        }
+    }
+
+    publications {
+        register<MavenPublication>("release") {
+            groupId = project.group.toString()
+            artifactId = "rusaint"
+            setVersion(project.version)
+
+            afterEvaluate {
+                from(components["release"])
+            }
+
+            pom {
+                name.set("rusaint")
+                description.set(project.description)
+                url.set("https://github.com/eatsteak/rusaint")
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://raw.githubusercontent.com/EATSTEAK/rusaint/refs/heads/main/LICENSE")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("eatsteak")
+                        name.set("Koo Hyomin")
+                        url.set("https://eatsteak.dev")
+                        email.set("me@eatsteak.dev")
+                    }
+                }
+                scm {
+                    connection = "scm:git:https://github.com/eatsteak/rusaint.git"
+                    developerConnection = "scm:git:ssh://github.com/eatsteak/rusaint.git"
+                    url = "https://github.com/eatsteak/rusaint"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
# What's in this pull request
- [`Sonatype Maven Central`](https://central.sonatype.com/artifact/dev.eatsteak/rusaint)에 배포할 수 있도록 설정했습니다.
- `main`에 push할 경우 jrelease를 통한 릴리즈 및 배포를 수행합니다(작업 중).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the JReleaser plugin to enhance the release management process.
	- Added a new GitHub Actions workflow for automated releases to Maven Central.

- **Improvements**
	- Upgraded Android Gradle Plugin to version 8.5.2 for better performance.
	- Enhanced error handling and binding generation process.
	- Updated project configuration with explicit group, description, and version details.

- **Bug Fixes**
	- Updated build configuration to optimize release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->