### PR TITLE
[chore] VSCode rust-analyzer 익스텐션 linkedProjects 필드 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "rust-analyzer.linkedProjects": ["./Cargo.toml", "./rusaint/Cargo.toml", "./rusaint-ffi/Cargo.toml"]
+  "rust-analyzer.linkedProjects": [
+    "Cargo.toml",
+    "packages/rusaint/Cargo.toml",
+    "packages/rusaint-ffi/Cargo.toml"
+  ]
 }


### PR DESCRIPTION
- 71c19a5491a40cbd91dfc0a5d193712c4c990704 에서 `rusaint` 패키지와 `rusaint-ffi` 패키지의 위치가 packages 디렉토리 하위로 변경되었지만 rust-analyzer의 `linkedProjects` 필드에는 반영이 안되어있어 수정

- `linkedProjects` 필드 수정 전 rust-analyzer language server 출력
<img width="964" alt="image" src="https://github.com/user-attachments/assets/cd7843d5-520a-414d-a644-1bf3ef8a21b2">

- `linkedProjects` 필드 수정 후에는 rust-analyzer language server가 정상적으로 동작함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated project paths in the development environment for improved organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->