### PR TITLE
[fix] `SapTable`의 잘못된 `rowspan` 처리

### DIFF
--- a/packages/rusaint/src/webdynpro/element/complex/sap_table/body.rs
+++ b/packages/rusaint/src/webdynpro/element/complex/sap_table/body.rs
@@ -22,6 +22,7 @@ pub struct SapTableBody {
 }
 
 impl<'a> SapTableBody {
+    /// TODO: Implement unit test for rowspan/colspan handling
     pub(super) fn new(
         table_def: SapTableDef,
         elem_ref: ElementRef<'a>,
@@ -96,7 +97,7 @@ impl<'a> SapTableBody {
                     if rowspan > 1 {
                         spans.insert(col_counter, (cell.clone(), rowspan, colspan));
                     }
-                    for _ in 0..rowspan {
+                    for _ in 0..colspan {
                         cells.push(cell.clone());
                         col_counter += 1;
                     }


### PR DESCRIPTION
# What's in this pull request
- `SapTable`의 최초 생성 과정에서 `rowspan`을 잘못 처리하여 파싱을 올바르게 할 수 없는 문제를 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of cell spans in table rendering.
	- Adjusted logic for processing cell references to enhance accuracy in display.

- **Chores**
	- Added a comment indicating the need for future unit tests related to rowspan and colspan handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->