### PR TITLE
[test] 실제 재학한 학기를 테스트 하기 위한 `TARGET_YEAR`, `TARGET_SEMESTER` 환경변수

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["main", "dev"]
+    branches: [ "main", "dev" ]
   schedule:
     - cron: "23 3 * * *"
 env:
@@ -15,6 +15,8 @@ jobs:
     env:
       SSO_ID: ${{ vars.SSO_ID }}
       SSO_PASSWORD: ${{ secrets.SSO_PASSWORD }}
+      TARGET_YEAR: ${{ vars.TARGET_YEAR }}
+      TARGET_SEMESTER: ${{ vars.TARGET_SEMESTER }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -2,7 +2,7 @@ name: Dry-run before publish
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
 env:
   CARGO_TERM_COLOR: always
 jobs:
@@ -12,6 +12,8 @@ jobs:
     env:
       SSO_ID: ${{ vars.SSO_ID }}
       SSO_PASSWORD: ${{ secrets.SSO_PASSWORD }}
+      TARGET_YEAR: ${{ vars.TARGET_YEAR }}
+      TARGET_SEMESTER: ${{ vars.TARGET_SEMESTER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/rusaint-ffi/src/application/course_grades.rs
+++ b/packages/rusaint-ffi/src/application/course_grades.rs
@@ -52,7 +52,7 @@ impl CourseGradesApplication {
     pub async fn classes(
         &self,
         course_type: CourseType,
-        year: u64,
+        year: u32,
         semester: SemesterType,
         include_details: bool,
     ) -> Result<Vec<ClassGrade>, RusaintError> {
@@ -68,7 +68,7 @@ impl CourseGradesApplication {
     pub async fn class_detail(
         &self,
         course_type: CourseType,
-        year: u64,
+        year: u32,
         semester: SemesterType,
         code: &str,
     ) -> Result<HashMap<String, f32>, RusaintError> {

--- a/packages/rusaint/src/application/course_grades/mod.rs
+++ b/packages/rusaint/src/application/course_grades/mod.rs
@@ -385,7 +385,7 @@ impl<'a> CourseGradesApplication {
     pub async fn classes(
         &mut self,
         course_type: CourseType,
-        year: u64,
+        year: u32,
         semester: SemesterType,
         include_details: bool,
     ) -> Result<Vec<ClassGrade>, RusaintError> {
@@ -472,7 +472,7 @@ impl<'a> CourseGradesApplication {
     pub async fn class_detail(
         &mut self,
         course_type: CourseType,
-        year: u64,
+        year: u32,
         semester: SemesterType,
         code: &str,
     ) -> Result<HashMap<String, f32>, RusaintError> {

--- a/packages/rusaint/src/lib.rs
+++ b/packages/rusaint/src/lib.rs
@@ -87,11 +87,10 @@ pub mod global_test_utils {
     use dotenv::dotenv;
     use std::sync::{Arc, OnceLock};
 
-    use crate::USaintSession;
-
-    pub static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();
+    use crate::{model::SemesterType, USaintSession};
 
     pub async fn get_session() -> Result<Arc<USaintSession>> {
+        static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();
         if let Some(session) = SESSION.get() {
             Ok(session.to_owned())
         } else {
@@ -104,6 +103,43 @@ pub mod global_test_utils {
                 .get()
                 .map(|arc| arc.to_owned())
                 .ok_or(Error::msg("Session is not initsiated"))
+        }
+    }
+
+    #[cfg(feature = "application")]
+    pub async fn get_year() -> Result<i32> {
+        static TARGET_YEAR: OnceLock<i32> = OnceLock::new();
+        if let Some(year) = TARGET_YEAR.get() {
+            Ok(*year)
+        } else {
+            let year = std::env::var("TARGET_YEAR")?.parse()?;
+            let _ = TARGET_YEAR.set(year);
+            TARGET_YEAR
+                .get()
+                .copied()
+                .ok_or(Error::msg("Year is not initsiated"))
+        }
+    }
+
+    #[cfg(feature = "application")]
+    pub fn get_semester() -> Result<SemesterType> {
+        static TARGET_SEMESTER: OnceLock<SemesterType> = OnceLock::new();
+        if let Some(semester) = TARGET_SEMESTER.get() {
+            Ok(*semester)
+        } else {
+            let semester = std::env::var("TARGET_SEMESTER")?;
+            let semester_type = match semester.to_uppercase().as_str() {
+                "1" | "ONE" => SemesterType::One,
+                "SUMMER" => SemesterType::Summer,
+                "2" | "TWO" => SemesterType::Two,
+                "WINTER" => SemesterType::Winter,
+                _ => return Err(Error::msg("Invalid semester")),
+            };
+            let _ = TARGET_SEMESTER.set(semester_type);
+            TARGET_SEMESTER
+                .get()
+                .copied()
+                .ok_or(Error::msg("Semester is not initsiated"))
         }
     }
 }

--- a/packages/rusaint/tests/application/chapel.rs
+++ b/packages/rusaint/tests/application/chapel.rs
@@ -1,11 +1,10 @@
+use crate::{get_semester, get_session, get_year};
+use rusaint::model::SemesterType;
 use rusaint::{
     application::{chapel::ChapelApplication, USaintClientBuilder},
-    model::SemesterType,
     ApplicationError, RusaintError,
 };
 use serial_test::serial;
-
-use crate::get_session;
 
 #[tokio::test]
 #[serial]
@@ -16,7 +15,10 @@ async fn chapel() {
         .build_into::<ChapelApplication>()
         .await
         .unwrap();
-    let info = app.information(2022, SemesterType::Two).await.unwrap();
+    let info = app
+        .information(get_year().unwrap(), get_semester().unwrap())
+        .await
+        .unwrap();
     println!("{:?}", info);
 }
 
@@ -29,7 +31,7 @@ async fn no_chapel() {
         .build_into::<ChapelApplication>()
         .await
         .unwrap();
-    let info = app.information(2024, SemesterType::Two).await.unwrap_err();
+    let info = app.information(2017, SemesterType::Two).await.unwrap_err();
     assert!(matches!(
         info,
         RusaintError::ApplicationError(ApplicationError::NoChapelInformation)

--- a/packages/rusaint/tests/application/course_grades.rs
+++ b/packages/rusaint/tests/application/course_grades.rs
@@ -1,13 +1,10 @@
-use rusaint::{
-    application::{
-        course_grades::{model::CourseType, CourseGradesApplication},
-        USaintClientBuilder,
-    },
-    model::SemesterType,
+use rusaint::application::{
+    course_grades::{model::CourseType, CourseGradesApplication},
+    USaintClientBuilder,
 };
 use serial_test::serial;
 
-use crate::get_session;
+use crate::{get_semester, get_session, get_year};
 
 #[tokio::test]
 #[serial]
@@ -67,7 +64,12 @@ async fn classes_with_detail() {
         .await
         .unwrap();
     let details = app
-        .classes(CourseType::Bachelor, 2022, SemesterType::Two, true)
+        .classes(
+            CourseType::Bachelor,
+            get_year().unwrap(),
+            get_semester().unwrap(),
+            true,
+        )
         .await
         .unwrap();
     println!("{:?}", details);
@@ -80,8 +82,8 @@ async fn classes_with_detail() {
     let detail = app
         .class_detail(
             CourseType::Bachelor,
-            2022,
-            SemesterType::Two,
+            get_year().unwrap(),
+            get_semester().unwrap(),
             detail_code.code(),
         )
         .await

--- a/packages/rusaint/tests/application/personal_course_schedule.rs
+++ b/packages/rusaint/tests/application/personal_course_schedule.rs
@@ -1,13 +1,12 @@
+use crate::{get_semester, get_session, get_year};
+use rusaint::model::SemesterType;
 use rusaint::{
     application::{
         personal_course_schedule::PersonalCourseScheduleApplication, USaintClientBuilder,
     },
-    model::SemesterType,
     ApplicationError, RusaintError,
 };
 use serial_test::serial;
-
-use crate::get_session;
 
 #[tokio::test]
 #[serial]
@@ -18,7 +17,10 @@ async fn schedule() {
         .build_into::<PersonalCourseScheduleApplication>()
         .await
         .unwrap();
-    let info = app.schedule(2022, SemesterType::Two).await.unwrap();
+    let info = app
+        .schedule(get_year().unwrap(), get_semester().unwrap())
+        .await
+        .unwrap();
     println!("{:?}", info);
 }
 
@@ -31,7 +33,7 @@ async fn no_schedule() {
         .build_into::<PersonalCourseScheduleApplication>()
         .await
         .unwrap();
-    let info = app.schedule(2024, SemesterType::Two).await.unwrap_err();
+    let info = app.schedule(2017, SemesterType::Two).await.unwrap_err();
     assert!(matches!(
         info,
         RusaintError::ApplicationError(ApplicationError::NoScheduleInformation)

--- a/packages/rusaint/tests/tests.rs
+++ b/packages/rusaint/tests/tests.rs
@@ -2,11 +2,10 @@ use anyhow::{Error, Result};
 use dotenv::dotenv;
 use std::sync::{Arc, OnceLock};
 
-use rusaint::USaintSession;
-
-static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();
+use rusaint::{model::SemesterType, USaintSession};
 
 pub async fn get_session() -> Result<Arc<USaintSession>> {
+    static SESSION: OnceLock<Arc<USaintSession>> = OnceLock::new();
     if let Some(session) = SESSION.get() {
         Ok(session.to_owned())
     } else {
@@ -19,6 +18,41 @@ pub async fn get_session() -> Result<Arc<USaintSession>> {
             .get()
             .map(|arc| arc.to_owned())
             .ok_or(Error::msg("Session is not initsiated"))
+    }
+}
+
+pub fn get_year() -> Result<u32> {
+    static TARGET_YEAR: OnceLock<u32> = OnceLock::new();
+    if let Some(year) = TARGET_YEAR.get() {
+        Ok(*year)
+    } else {
+        let year = std::env::var("TARGET_YEAR")?.parse()?;
+        let _ = TARGET_YEAR.set(year);
+        TARGET_YEAR
+            .get()
+            .copied()
+            .ok_or(Error::msg("Year is not initsiated"))
+    }
+}
+
+pub fn get_semester() -> Result<SemesterType> {
+    static TARGET_SEMESTER: OnceLock<SemesterType> = OnceLock::new();
+    if let Some(semester) = TARGET_SEMESTER.get() {
+        Ok(*semester)
+    } else {
+        let semester = std::env::var("TARGET_SEMESTER")?;
+        let semester_type = match semester.to_uppercase().as_str() {
+            "1" | "ONE" => SemesterType::One,
+            "SUMMER" => SemesterType::Summer,
+            "2" | "TWO" => SemesterType::Two,
+            "WINTER" => SemesterType::Winter,
+            _ => return Err(Error::msg("Invalid semester")),
+        };
+        let _ = TARGET_SEMESTER.set(semester_type);
+        TARGET_SEMESTER
+            .get()
+            .copied()
+            .ok_or(Error::msg("Semester is not initsiated"))
     }
 }
 


### PR DESCRIPTION
# What's in this pull request
- 테스트 대상자가 실제 재학한 학기를 테스트 하기 위한 `TARGET_YEAR`, `TARGET_SEMESTER` 환경변수 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added environment variables `TARGET_YEAR` and `TARGET_SEMESTER` for enhanced configuration management.
	- Introduced new functions `get_year` and `get_semester` for retrieving configuration values dynamically.

- **Bug Fixes**
	- Updated method signatures for `classes` and `class_detail` to use `u32` for the year parameter, improving type consistency.

- **Tests**
	- Updated tests to utilize dynamic retrieval of year and semester values instead of hardcoded constants, enhancing test flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->