### PR TITLE
[fix] 전체 테이블을 가져오지 못한 경우 스크롤하여 파싱

### DIFF
--- a/packages/rusaint/src/application/course_schedule/mod.rs
+++ b/packages/rusaint/src/application/course_schedule/mod.rs
@@ -1,4 +1,5 @@
 use super::{USaintApplication, USaintClient};
+use crate::application::utils::sap_table::try_table_into_with_scroll;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
@@ -128,7 +129,9 @@ impl<'a> CourseScheduleApplication {
                 }
             }
         }
-        let lectures = table.try_table_into::<Lecture>(&parser)?;
+        let lectures =
+            try_table_into_with_scroll::<Lecture>(&mut self.client, parser, Self::MAIN_TABLE)
+                .await?;
         Ok(lectures.into_iter())
     }
 

--- a/packages/rusaint/src/application/student_information/model/academic_record.rs
+++ b/packages/rusaint/src/application/student_information/model/academic_record.rs
@@ -5,13 +5,14 @@ use serde::{
     Deserialize,
 };
 
+use crate::application::utils::sap_table::try_table_into_with_scroll;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
     application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
-        command::element::{complex::SapTableBodyCommand, layout::TabStripTabSelectEventCommand},
+        command::element::layout::TabStripTabSelectEventCommand,
         element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
@@ -47,8 +48,9 @@ impl<'a> StudentAcademicRecords {
         ))?;
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
-        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_9600))?;
-        let records = table.try_table_into::<StudentAcademicRecord>(&parser)?;
+        let records =
+            try_table_into_with_scroll::<StudentAcademicRecord>(client, parser, Self::TABLE_9600)
+                .await?;
         Ok(Self { records })
     }
 

--- a/packages/rusaint/src/application/student_information/model/family.rs
+++ b/packages/rusaint/src/application/student_information/model/family.rs
@@ -6,13 +6,14 @@ use serde::{
 };
 
 use crate::application::utils::de_with::{deserialize_bool_string, deserialize_optional_string};
+use crate::application::utils::sap_table::try_table_into_with_scroll;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
     application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
-        command::element::{complex::SapTableBodyCommand, layout::TabStripTabSelectEventCommand},
+        command::element::layout::TabStripTabSelectEventCommand,
         element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
@@ -48,8 +49,9 @@ impl<'a> StudentFamily {
         ))?;
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
-        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_FAMILY))?;
-        let members = table.try_table_into::<StudentFamilyMember>(&parser)?;
+        let members =
+            try_table_into_with_scroll::<StudentFamilyMember>(client, parser, Self::TABLE_FAMILY)
+                .await?;
         Ok(Self { members })
     }
 

--- a/packages/rusaint/src/application/student_information/model/transfer.rs
+++ b/packages/rusaint/src/application/student_information/model/transfer.rs
@@ -5,13 +5,14 @@ use serde::{
     Deserialize,
 };
 
+use crate::application::utils::sap_table::try_table_into_with_scroll;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
     application::{student_information::StudentInformationApplication, USaintClient},
     define_elements,
     webdynpro::{
-        command::element::{complex::SapTableBodyCommand, layout::TabStripTabSelectEventCommand},
+        command::element::layout::TabStripTabSelectEventCommand,
         element::{
             complex::{sap_table::FromSapTable, SapTable},
             definition::ElementDefinition,
@@ -47,8 +48,12 @@ impl<'a> StudentTransferRecords {
         ))?;
         client.process_event(false, event).await?;
         parser = ElementParser::new(client.body());
-        let table = parser.read(SapTableBodyCommand::new(Self::TABLE_TRANSFER))?;
-        let records = table.try_table_into::<StudentTransferRecord>(&parser)?;
+        let records = try_table_into_with_scroll::<StudentTransferRecord>(
+            client,
+            parser,
+            Self::TABLE_TRANSFER,
+        )
+        .await?;
         Ok(Self { records })
     }
 

--- a/packages/rusaint/src/application/utils/mod.rs
+++ b/packages/rusaint/src/application/utils/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod de_with;
 pub(crate) mod input_field;
+pub(crate) mod sap_table;

--- a/packages/rusaint/src/application/utils/sap_table.rs
+++ b/packages/rusaint/src/application/utils/sap_table.rs
@@ -1,0 +1,55 @@
+use crate::application::USaintClient;
+use crate::webdynpro::command::element::complex::{
+    SapTableBodyCommand, SapTableLSDataCommand, SapTableVerticalScrollEventCommand,
+};
+use crate::webdynpro::command::WebDynproCommandExecutor;
+use crate::webdynpro::element::complex::sap_table::FromSapTable;
+use crate::webdynpro::element::complex::SapTableDef;
+use crate::webdynpro::element::definition::ElementDefinition;
+use crate::webdynpro::element::parser::ElementParser;
+use crate::webdynpro::error::{ElementError, WebDynproError};
+
+pub(crate) async fn try_table_into_with_scroll<T: for<'body> FromSapTable<'body>>(
+    client: &mut USaintClient,
+    mut parser: ElementParser,
+    table: SapTableDef,
+) -> Result<Vec<T>, WebDynproError> {
+    let row_count = parser
+        .read(SapTableLSDataCommand::new(table.clone()))?
+        .row_count()
+        .map(|u| u.to_owned())
+        .ok_or_else(|| {
+            WebDynproError::Element(ElementError::NoSuchData {
+                element: table.clone().id().to_string(),
+                field: "row_count".to_string(),
+            })
+        })?
+        .try_into()
+        .unwrap();
+    let mut table_body = parser.read(SapTableBodyCommand::new(table.clone()))?;
+    let mut results: Vec<T> = Vec::with_capacity(row_count);
+    while results.len() < row_count {
+        let mut partial_results = table_body.try_table_into::<T>(&parser)?;
+        if results.len() + partial_results.len() > row_count {
+            let overflowed = results.len() + partial_results.len() - row_count;
+            partial_results.drain(0..overflowed);
+        }
+        results.append(&mut partial_results);
+        if results.len() < row_count {
+            let event = parser.read(SapTableVerticalScrollEventCommand::new(
+                table.clone(),
+                results.len().try_into().unwrap(),
+                "",
+                "SCROLLBAR",
+                false,
+                false,
+                false,
+                false,
+            ))?;
+            client.process_event(false, event).await?;
+            parser = ElementParser::new(client.body());
+            table_body = parser.read(SapTableBodyCommand::new(table.clone()))?;
+        }
+    }
+    Ok(results)
+}


### PR DESCRIPTION
# What's in this pull request
- 전체 테이블을 가져오지 못한 경우 스크롤하여 파싱(resolved #124)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new utility function for asynchronous table data retrieval, enhancing data handling across various applications.
	- Added a new module for SAP table utilities.

- **Bug Fixes**
	- Improved error handling for data retrieval processes across multiple applications.

- **Documentation**
	- Updated method signatures to reflect changes in asynchronous processing.

- **Chores**
	- Streamlined internal logic for data retrieval in several applications, reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->