### PR TITLE
[ci] `yq`액션을 릴리즈에 사용하지 않도록 변경

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -21,9 +21,7 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Get rusaint version
         id: current_version
-        uses: mikefarah/yq@v4
-        with:
-          cmd: yq '.workspace.package.version | "v" + .' Cargo.toml
+        run: yq '.workspace.package.version | "result=v" + .' Cargo.toml >> $GITHUB_OUTPUT
       - name: Fetch latest release tag
         id: latest_release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Get rusaint version
         id: current_version
-        uses: mikefarah/yq@v4
-        with:
-          cmd: yq '.workspace.package.version | "v" + .' Cargo.toml
+        run: yq '.workspace.package.version | "result=v" + .' Cargo.toml >> $GITHUB_OUTPUT
       - name: Fetch latest release tag
         id: latest_release
         run: |


### PR DESCRIPTION
# What's in this pull request
- Actions runner 이미지의 `yq`를 `yq` 액션 대신 사용
  - `macos-latest`에서는 yq 액션의 사용이 불가능