### PR TITLE
[fix] 겨울학기의 key가 잘못 입력됨

### DIFF
--- a/packages/rusaint/src/application/chapel/mod.rs
+++ b/packages/rusaint/src/application/chapel/mod.rs
@@ -47,7 +47,7 @@ impl<'a> ChapelApplication {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",
-            SemesterType::Winter => "0923",
+            SemesterType::Winter => "093",
         }
     }
 

--- a/packages/rusaint/src/application/course_grades/mod.rs
+++ b/packages/rusaint/src/application/course_grades/mod.rs
@@ -113,7 +113,7 @@ impl<'a> CourseGradesApplication {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",
-            SemesterType::Winter => "0923",
+            SemesterType::Winter => "093",
         }
     }
 

--- a/packages/rusaint/src/application/lecture_assessment/mod.rs
+++ b/packages/rusaint/src/application/lecture_assessment/mod.rs
@@ -64,7 +64,7 @@ impl<'a> LectureAssessmentApplication {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",
-            SemesterType::Winter => "0923",
+            SemesterType::Winter => "093",
         }
     }
 

--- a/packages/rusaint/src/application/personal_course_schedule/mod.rs
+++ b/packages/rusaint/src/application/personal_course_schedule/mod.rs
@@ -47,7 +47,7 @@ impl<'a> PersonalCourseScheduleApplication {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",
-            SemesterType::Winter => "0923",
+            SemesterType::Winter => "093",
         }
     }
 

--- a/packages/rusaint/tests/application/course_grades.rs
+++ b/packages/rusaint/tests/application/course_grades.rs
@@ -75,10 +75,12 @@ async fn classes_with_detail() {
     println!("{:?}", details);
     assert!(!details.is_empty());
     println!("Try to obtain class's detail");
-    let detail_code = details
-        .iter()
-        .find(|grade| grade.detail().is_some())
-        .unwrap();
+    let detail_code = details.iter().find(|grade| grade.detail().is_some());
+    if detail_code.is_none() {
+        println!("No class found with detail");
+        return;
+    }
+    let detail_code = detail_code.unwrap();
     let detail = app
         .class_detail(
             CourseType::Bachelor,


### PR DESCRIPTION
# What's in this pull request
- 겨울학기(`SemesterType::Winter`)의 key가 잘못 입력되어 파싱하지 못하는 현상 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling in the `classes_with_detail` test to prevent panics when no class with detail is found.
  
- **Changes**
	- Adjusted the mapping for the winter semester from `"0923"` to `"093"` across multiple applications, affecting how the winter semester is represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->