### PR TITLE
[fix] 성적 점수가 비었을 때를 위한 `ClassScore::Empty`

### DIFF
--- a/packages/rusaint/src/application/course_grades/model.rs
+++ b/packages/rusaint/src/application/course_grades/model.rs
@@ -386,6 +386,8 @@ pub enum ClassScore {
     Failed,
     /// 일반 과목의 점수
     Score(u32),
+    /// 성적 없음
+    Empty,
 }
 
 impl FromStr for ClassScore {
@@ -395,6 +397,7 @@ impl FromStr for ClassScore {
         Ok(match s {
             "P" => Self::Pass,
             "F" => Self::Failed,
+            "" => Self::Empty,
             _ => Self::Score(s.parse::<u32>()?),
         })
     }


### PR DESCRIPTION
# What's in this pull request
- 성적 점수가 비었을 때(처리되지 않았을 경우)를 위한 `ClassScore::Empty` enum variant 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new state, `Empty`, to represent cases with no score provided in the grading system.
	- Enhanced string parsing to recognize and handle empty score inputs effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->