### PR TITLE
[fix] 개인 시간표 상 교수 이름이 없는 과목 처리

### DIFF
--- a/packages/rusaint/src/application/personal_course_schedule/mod.rs
+++ b/packages/rusaint/src/application/personal_course_schedule/mod.rs
@@ -103,57 +103,63 @@ impl<'a> PersonalCourseScheduleApplication {
                         .for_each(|(col_idx, str)| match col_idx {
                             0 => {
                                 schedule.entry(Weekday::Mon).or_default();
-                                str.split("\n\n").for_each(|str| {
+                                let mut iter = str.split("\n").peekable();
+                                while iter.peek().is_some() {
                                     schedule
                                         .get_mut(&Weekday::Mon)
                                         .unwrap()
-                                        .push(CourseScheduleInformation::from_string(str))
-                                });
+                                        .push(CourseScheduleInformation::from_iter(&mut iter))
+                                }
                             }
                             1 => {
                                 schedule.entry(Weekday::Tue).or_default();
-                                str.split("\n\n").for_each(|str| {
+                                let mut iter = str.split("\n").peekable();
+                                while iter.peek().is_some() {
                                     schedule
                                         .get_mut(&Weekday::Tue)
                                         .unwrap()
-                                        .push(CourseScheduleInformation::from_string(str))
-                                });
+                                        .push(CourseScheduleInformation::from_iter(&mut iter))
+                                }
                             }
                             2 => {
                                 schedule.entry(Weekday::Wed).or_default();
-                                str.split("\n\n").for_each(|str| {
+                                let mut iter = str.split("\n").peekable();
+                                while iter.peek().is_some() {
                                     schedule
                                         .get_mut(&Weekday::Wed)
                                         .unwrap()
-                                        .push(CourseScheduleInformation::from_string(str))
-                                });
+                                        .push(CourseScheduleInformation::from_iter(&mut iter))
+                                }
                             }
                             3 => {
                                 schedule.entry(Weekday::Thu).or_default();
-                                str.split("\n\n").for_each(|str| {
+                                let mut iter = str.split("\n").peekable();
+                                while iter.peek().is_some() {
                                     schedule
                                         .get_mut(&Weekday::Thu)
                                         .unwrap()
-                                        .push(CourseScheduleInformation::from_string(str))
-                                });
+                                        .push(CourseScheduleInformation::from_iter(&mut iter))
+                                }
                             }
                             4 => {
                                 schedule.entry(Weekday::Fri).or_default();
-                                str.split("\n\n").for_each(|str| {
+                                let mut iter = str.split("\n").peekable();
+                                while iter.peek().is_some() {
                                     schedule
                                         .get_mut(&Weekday::Fri)
                                         .unwrap()
-                                        .push(CourseScheduleInformation::from_string(str))
-                                });
+                                        .push(CourseScheduleInformation::from_iter(&mut iter))
+                                }
                             }
                             5 => {
                                 schedule.entry(Weekday::Sat).or_default();
-                                str.split("\n\n").for_each(|str| {
+                                let mut iter = str.split("\n").peekable();
+                                while iter.peek().is_some() {
                                     schedule
                                         .get_mut(&Weekday::Sat)
                                         .unwrap()
-                                        .push(CourseScheduleInformation::from_string(str))
-                                });
+                                        .push(CourseScheduleInformation::from_iter(&mut iter))
+                                }
                             }
                             _ => {}
                         });

--- a/packages/rusaint/src/application/personal_course_schedule/model.rs
+++ b/packages/rusaint/src/application/personal_course_schedule/model.rs
@@ -38,13 +38,16 @@ pub struct CourseScheduleInformation {
 }
 
 impl CourseScheduleInformation {
-    pub(crate) fn from_string(str: &str) -> CourseScheduleInformation {
-        let mut splited = str.split("\n");
+    pub(crate) fn from_iter<'a>(
+        iter: &mut impl Iterator<Item = &'a str>,
+    ) -> CourseScheduleInformation {
+        let mut iter = iter.skip_while(|s| s.is_empty());
+        // Consume empty strings at start
         CourseScheduleInformation {
-            name: splited.next().unwrap().to_string(),
-            professor: splited.next().unwrap().to_string(),
-            time: splited.next().unwrap().to_string(),
-            classroom: splited.next().unwrap_or("").to_string(),
+            name: iter.next().unwrap().to_string(),
+            professor: iter.next().unwrap().to_string(),
+            time: iter.next().unwrap().to_string(),
+            classroom: iter.next().unwrap_or("").to_string(),
         }
     }
 


### PR DESCRIPTION
# What's in this pull request
- 개인 시간표 상에 교수 이름이 없는 과목이 없을 경우 파싱에 실패하는 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parsing logic for course schedule entries, allowing for more flexible input handling.
- **Bug Fixes**
	- Improved error handling for course schedule data processing.
- **Refactor**
	- Replaced the `from_string` method with a new `from_iter` method for better robustness in input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->