### PR TITLE
[fix(application/course_schedule)] 과목 코드에 올바르지 않은 정보가 표기됨

### DIFF
--- a/packages/rusaint/src/webdynpro/element/mod.rs
+++ b/packages/rusaint/src/webdynpro/element/mod.rs
@@ -371,6 +371,12 @@ impl ElementWrapper<'_> {
             ElementWrapper::TextView(tv) => Ok(tv.text().to_string()),
             ElementWrapper::Caption(cp) => Ok(cp.text().to_string()),
             ElementWrapper::CheckBox(c) => Ok(format!("{}", c.checked())),
+            ElementWrapper::Link(l) => Ok(l
+                .lsdata()
+                .text()
+                .map(String::as_str)
+                .unwrap_or(l.id())
+                .to_string()),
             _ => Err(WebDynproError::Element(ElementError::InvalidContent {
                 element: self.id().to_string(),
                 content: "This element is cannot be textised.".to_string(),


### PR DESCRIPTION
# What's in this pull request
- `CourseScheduleApplication`에서 `Lecture` 데이터가 포함된 정보를 불러올 때 `Lecture::code` 필드가 올바르지 않은 정보(엘리먼트 ID)가 표기되는 문제 해결
- 문제 해결을 위해 `ElementWrapper::textise` 함수가 `Link` 엘리먼트를 적절하게 텍스트로 변환하도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced link text retrieval in the application's element handling
	- Improved text extraction for link elements with fallback to link ID
<!-- end of auto-generated comment: release notes by coderabbit.ai -->