### PR TITLE
[feat(application)] 선택지 가져오기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,10 @@ languages/swift/RusaintFFI.modulemap
 # xcframework
 languages/swift/RusaintFFI.xcframework/
 
+# JetBrains IDEs
+.idea
+
+# gradle
+.gradle
 
 

--- a/packages/rusaint-ffi/src/application/chapel.rs
+++ b/packages/rusaint-ffi/src/application/chapel.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use rusaint::{application::chapel::model::ChapelInformation, model::SemesterType};
 use tokio::sync::RwLock;
 
+use crate::application::model::YearSemester;
 use crate::{error::RusaintError, session::USaintSession};
 
 /// [채플정보조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW3681)
@@ -18,6 +19,13 @@ impl ChapelApplication {
         semester: SemesterType,
     ) -> Result<ChapelInformation, RusaintError> {
         Ok(self.0.write().await.information(year, semester).await?)
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub async fn get_selected_semester(&self) -> Result<YearSemester, RusaintError> {
+        let (year, semester) = self.0.read().await.get_selected_semester()?;
+        Ok(YearSemester::new(year, semester))
     }
 }
 

--- a/packages/rusaint-ffi/src/application/course_grades.rs
+++ b/packages/rusaint-ffi/src/application/course_grades.rs
@@ -6,6 +6,7 @@ use rusaint::{
 };
 use tokio::sync::RwLock;
 
+use crate::application::model::YearSemester;
 use crate::{error::RusaintError, session::USaintSession};
 
 /// [학생 성적 조회](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMB3W0017)
@@ -78,6 +79,13 @@ impl CourseGradesApplication {
             .await
             .class_detail(course_type, year, semester, code)
             .await?)
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub async fn get_selected_semester(&self) -> Result<YearSemester, RusaintError> {
+        let (year, semester) = self.0.read().await.get_selected_semester()?;
+        Ok(YearSemester::new(year, semester))
     }
 }
 

--- a/packages/rusaint-ffi/src/application/course_schedule.rs
+++ b/packages/rusaint-ffi/src/application/course_schedule.rs
@@ -20,14 +20,14 @@ impl CourseScheduleApplication {
     pub async fn find_lectures(
         &self,
         year: u32,
-        period: SemesterType,
+        semester: SemesterType,
         lecture_category: &LectureCategory,
     ) -> Result<Vec<Lecture>, RusaintError> {
         Ok(self
             .0
             .write()
             .await
-            .find_lectures(year, period, lecture_category)
+            .find_lectures(year, semester, lecture_category)
             .await?
             .collect())
     }

--- a/packages/rusaint-ffi/src/application/course_schedule.rs
+++ b/packages/rusaint-ffi/src/application/course_schedule.rs
@@ -39,6 +39,140 @@ impl CourseScheduleApplication {
         let (year, semester) = self.0.read().await.get_selected_semester()?;
         Ok(YearSemester::new(year, semester))
     }
+
+    /// 선택한 학기 기준 단과대 목록을 가져옵니다.
+    pub async fn collages(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self.0.write().await.collages(year, semester).await?)
+    }
+
+    /// 선택한 학기 기준 주어진 단과대의 학과(부) 목록을 가져옵니다.
+    pub async fn departments(
+        &self,
+        year: u32,
+        semester: SemesterType,
+        collage: &str,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .departments(year, semester, collage)
+            .await?)
+    }
+
+    /// 선택한 학과(부)의 전공 목록을 가져옵니다.
+    pub async fn majors(
+        &self,
+        year: u32,
+        semester: SemesterType,
+        collage: &str,
+        department: &str,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .majors(year, semester, collage, department)
+            .await?)
+    }
+
+    /// 선택한 학기의 교양필수 과목명 목록을 가져옵니다.
+    pub async fn required_electives(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .required_electives(year, semester)
+            .await?)
+    }
+
+    /// 선택한 학기의 교양선택 분야 목록을 가져옵니다.
+    pub async fn optional_elective_categories(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .optional_elective_categories(year, semester)
+            .await?)
+    }
+
+    /// 선택한 학기의 채플 과목 분류 목록을 가져옵니다.
+    pub async fn chapel_categories(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .chapel_categories(year, semester)
+            .await?)
+    }
+
+    /// 선택한 학기의 대학원 단과대학 목록을 가져옵니다.
+    pub async fn graduated_collages(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .graduated_collages(year, semester)
+            .await?)
+    }
+
+    /// 선택한 학기의 주어진 대학원 단과대의 학과 목록을 가져옵니다.
+    pub async fn graduated_departments(
+        &self,
+        year: u32,
+        semester: SemesterType,
+        collage: &str,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .graduated_departments(year, semester, collage)
+            .await?)
+    }
+
+    /// 선택한 학기의 연계전공 목록을 가져옵니다.
+    pub async fn connected_majors(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self
+            .0
+            .write()
+            .await
+            .connected_majors(year, semester)
+            .await?)
+    }
+
+    /// 선택한 학기의 융합전공 목록을 가져옵니다.
+    pub async fn united_majors(
+        &self,
+        year: u32,
+        semester: SemesterType,
+    ) -> Result<Vec<String>, RusaintError> {
+        Ok(self.0.write().await.united_majors(year, semester).await?)
+    }
 }
 
 /// [`CourseScheduleApplication`] 생성을 위한 빌더

--- a/packages/rusaint-ffi/src/application/course_schedule.rs
+++ b/packages/rusaint-ffi/src/application/course_schedule.rs
@@ -6,6 +6,7 @@ use rusaint::{
 };
 use tokio::sync::RwLock;
 
+use crate::application::model::YearSemester;
 use crate::{error::RusaintError, session::USaintSession};
 
 /// [강의시간표](https://ecc.ssu.ac.kr/sap/bc/webdynpro/SAP/ZCMW2100)
@@ -30,6 +31,13 @@ impl CourseScheduleApplication {
             .find_lectures(year, semester, lecture_category)
             .await?
             .collect())
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub async fn get_selected_semester(&self) -> Result<YearSemester, RusaintError> {
+        let (year, semester) = self.0.read().await.get_selected_semester()?;
+        Ok(YearSemester::new(year, semester))
     }
 }
 

--- a/packages/rusaint-ffi/src/application/lecture_assessment.rs
+++ b/packages/rusaint-ffi/src/application/lecture_assessment.rs
@@ -18,7 +18,7 @@ impl LectureAssessmentApplication {
     pub async fn find_assessments(
         &self,
         year: u32,
-        period: SemesterType,
+        semester: SemesterType,
         lecture_name: Option<String>,
         lecture_code: Option<u32>,
         professor_name: Option<String>,
@@ -29,7 +29,7 @@ impl LectureAssessmentApplication {
             .0
             .write()
             .await
-            .find_assessments(year, period, lecture_name, lecture_code, professor_name)
+            .find_assessments(year, semester, lecture_name, lecture_code, professor_name)
             .await?)
     }
 }

--- a/packages/rusaint-ffi/src/application/lecture_assessment.rs
+++ b/packages/rusaint-ffi/src/application/lecture_assessment.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::application::model::YearSemester;
 use crate::{error::RusaintError, session::USaintSession};
 use rusaint::application::lecture_assessment::model::LectureAssessmentResult;
 use rusaint::model::SemesterType;
@@ -31,6 +32,13 @@ impl LectureAssessmentApplication {
             .await
             .find_assessments(year, semester, lecture_name, lecture_code, professor_name)
             .await?)
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub async fn get_selected_semester(&self) -> Result<YearSemester, RusaintError> {
+        let (year, semester) = self.0.read().await.get_selected_semester()?;
+        Ok(YearSemester::new(year, semester))
     }
 }
 

--- a/packages/rusaint-ffi/src/application/mod.rs
+++ b/packages/rusaint-ffi/src/application/mod.rs
@@ -18,3 +18,6 @@ pub mod personal_course_schedule;
 
 /// 강의평가 조회: [`LectureAssessmentApplication`](lecture_assessment::LectureAssessmentApplication)
 pub mod lecture_assessment;
+
+/// 플랫폼 지원을 위한 데이터
+pub mod model;

--- a/packages/rusaint-ffi/src/application/model.rs
+++ b/packages/rusaint-ffi/src/application/model.rs
@@ -1,0 +1,13 @@
+use rusaint::model::SemesterType;
+
+#[derive(uniffi::Record)]
+pub struct YearSemester {
+    year: u32,
+    semester: SemesterType,
+}
+
+impl YearSemester {
+    pub fn new(year: u32, semester: SemesterType) -> YearSemester {
+        YearSemester { year, semester }
+    }
+}

--- a/packages/rusaint-ffi/src/application/personal_course_schedule.rs
+++ b/packages/rusaint-ffi/src/application/personal_course_schedule.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::application::model::YearSemester;
 use crate::{error::RusaintError, session::USaintSession};
 use rusaint::application::personal_course_schedule::model::PersonalCourseSchedule;
 use rusaint::model::SemesterType;
@@ -20,6 +21,13 @@ impl PersonalCourseScheduleApplication {
         semester: SemesterType,
     ) -> Result<PersonalCourseSchedule, RusaintError> {
         Ok(self.0.write().await.schedule(year, semester).await?)
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub async fn get_selected_semester(&self) -> Result<YearSemester, RusaintError> {
+        let (year, semester) = self.0.read().await.get_selected_semester()?;
+        Ok(YearSemester::new(year, semester))
     }
 }
 

--- a/packages/rusaint/src/application/chapel/mod.rs
+++ b/packages/rusaint/src/application/chapel/mod.rs
@@ -1,6 +1,7 @@
 use model::{ChapelAbsenceRequest, ChapelAttendance, ChapelInformation, GeneralChapelInformation};
 
 use super::{USaintApplication, USaintClient};
+use crate::application::utils::semester::get_selected_semester;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
@@ -115,6 +116,16 @@ impl<'a> ChapelApplication {
             attendances,
             absence_requests,
         ))
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub fn get_selected_semester(&self) -> Result<(u32, SemesterType), RusaintError> {
+        Ok(get_selected_semester(
+            &self.client,
+            &Self::SEL_PERYR,
+            &Self::SEL_PERID,
+        )?)
     }
 }
 

--- a/packages/rusaint/src/application/chapel/mod.rs
+++ b/packages/rusaint/src/application/chapel/mod.rs
@@ -44,8 +44,8 @@ impl<'a> ChapelApplication {
         BTN_SEL: Button<'a> = "ZCMW3681.ID_0001:V_MAIN.BTN_SEL";
     }
 
-    fn semester_to_key(period: SemesterType) -> &'static str {
-        match period {
+    fn semester_to_key(semester: SemesterType) -> &'static str {
+        match semester {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",

--- a/packages/rusaint/src/application/course_grades/mod.rs
+++ b/packages/rusaint/src/application/course_grades/mod.rs
@@ -1,6 +1,7 @@
 use self::model::{ClassGrade, CourseType, GradeSummary, SemesterGrade};
 use super::{USaintApplication, USaintClient};
 use crate::application::utils::sap_table::try_table_into_with_scroll;
+use crate::application::utils::semester::get_selected_semester;
 use crate::webdynpro::client::body::Body;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::complex::sap_table::cell::SapTableCellWrapper;
@@ -175,6 +176,16 @@ impl<'a> CourseGradesApplication {
                 .await?;
         }
         Ok(())
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub fn get_selected_semester(&self) -> Result<(u32, SemesterType), RusaintError> {
+        Ok(get_selected_semester(
+            &self.client,
+            &Self::PERIOD_YEAR,
+            &Self::PERIOD_SEMESTER,
+        )?)
     }
 
     /// 전체 학기의 학적부 평점 정보를 가져옵니다.

--- a/packages/rusaint/src/application/course_grades/mod.rs
+++ b/packages/rusaint/src/application/course_grades/mod.rs
@@ -110,8 +110,8 @@ impl<'a> CourseGradesApplication {
         Ok(())
     }
 
-    fn semester_to_key(period: SemesterType) -> &'static str {
-        match period {
+    fn semester_to_key(semester: SemesterType) -> &'static str {
+        match semester {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",

--- a/packages/rusaint/src/application/course_schedule/mod.rs
+++ b/packages/rusaint/src/application/course_schedule/mod.rs
@@ -53,8 +53,8 @@ impl<'a> CourseScheduleApplication {
         MAIN_TABLE: SapTable<'a> = "SALV_WD_TABLE.ID_DE0D9128A4327646C94670E2A892C99C:VIEW_TABLE.SALV_WD_UIE_TABLE";
     }
 
-    fn semester_to_key(period: SemesterType) -> &'static str {
-        match period {
+    fn semester_to_key(semester: SemesterType) -> &'static str {
+        match semester {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",
@@ -62,11 +62,11 @@ impl<'a> CourseScheduleApplication {
         }
     }
 
-    async fn select_period(
+    async fn select_semester(
         &mut self,
         parser: &ElementParser,
         year: &str,
-        period: SemesterType,
+        semester: SemesterType,
     ) -> Result<(), WebDynproError> {
         let year_select_event = parser.read(ComboBoxSelectEventCommand::new(
             Self::PERIOD_YEAR,
@@ -76,7 +76,7 @@ impl<'a> CourseScheduleApplication {
         self.client.process_event(false, year_select_event).await?;
         let semester_select_event = parser.read(ComboBoxSelectEventCommand::new(
             Self::PERIOD_ID,
-            Self::semester_to_key(period),
+            Self::semester_to_key(semester),
             false,
         ))?;
         self.client
@@ -117,14 +117,14 @@ impl<'a> CourseScheduleApplication {
     pub async fn find_lectures(
         &mut self,
         year: u32,
-        period: SemesterType,
+        semester: SemesterType,
         lecture_category: &LectureCategory,
     ) -> Result<impl Iterator<Item = Lecture>, RusaintError> {
         {
             let parser = ElementParser::new(self.body());
             let year_str = format!("{}", year);
             self.select_rows(&parser, 500).await?;
-            self.select_period(&parser, &year_str, period).await?;
+            self.select_semester(&parser, &year_str, semester).await?;
         }
         lecture_category.request_query(&mut self.client.0).await?;
         let parser = ElementParser::new(self.body());

--- a/packages/rusaint/src/application/course_schedule/mod.rs
+++ b/packages/rusaint/src/application/course_schedule/mod.rs
@@ -1,5 +1,6 @@
 use super::{USaintApplication, USaintClient};
 use crate::application::utils::sap_table::try_table_into_with_scroll;
+use crate::application::utils::semester::get_selected_semester;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
@@ -100,6 +101,16 @@ impl<'a> CourseScheduleApplication {
 
     fn body(&self) -> &Body {
         self.client.body()
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub fn get_selected_semester(&self) -> Result<(u32, SemesterType), RusaintError> {
+        Ok(get_selected_semester(
+            &self.client,
+            &Self::PERIOD_YEAR,
+            &Self::PERIOD_ID,
+        )?)
     }
 
     /// 학기, 학년도, 강의 분류를 통해 강의를 찾습니다.

--- a/packages/rusaint/src/application/course_schedule/model.rs
+++ b/packages/rusaint/src/application/course_schedule/model.rs
@@ -5,6 +5,9 @@ use serde::{
     Deserialize, Serialize,
 };
 
+use crate::application::course_schedule::utils::{
+    request, request_lv1, request_lv2, request_lv3, request_text,
+};
 use crate::application::utils::de_with::deserialize_optional_string;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
@@ -18,14 +21,8 @@ use crate::{
             selection::{ComboBoxChangeEventCommand, ComboBoxSelectByValue1EventCommand},
         },
         element::{
-            action::{Button, ButtonDef},
-            complex::sap_table::FromSapTable,
-            definition::ElementDefinition,
-            layout::{
-                tab_strip::item::{TabStripItem, TabStripItemDef},
-                TabStrip,
-            },
-            selection::{ComboBox, ComboBoxDef},
+            action::Button, complex::sap_table::FromSapTable, definition::ElementDefinition,
+            layout::tab_strip::item::TabStripItem, selection::ComboBox,
         },
         error::{ElementError, WebDynproError},
     },
@@ -103,10 +100,6 @@ pub enum LectureCategory {
 }
 
 impl LectureCategory {
-    define_elements! {
-        TABSTRIP: TabStrip<'static> = "ZCMW2100.ID_0001:VIW_MAIN.MODULE_TABSTRIP";
-    }
-
     /// 전공과목 분류의 [`LectureCategory`]를 만듭니다.
     pub fn major(collage: &str, department: &str, major: Option<&str>) -> Self {
         Self::Major {
@@ -211,7 +204,7 @@ impl LectureCategory {
                     SEARCH_OTHERS: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_OTHERS.BUTTON";
                 }
                 if let Some(major) = major {
-                    Self::request_lv3(
+                    request_lv3(
                         client,
                         TAB_OTHERS,
                         0,
@@ -225,7 +218,7 @@ impl LectureCategory {
                     )
                     .await?;
                 } else {
-                    Self::request_lv2(
+                    request_lv2(
                         client,
                         TAB_OTHERS,
                         0,
@@ -245,7 +238,7 @@ impl LectureCategory {
                     GENERAL_REQ_TYPE: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_GENERAL_REQ.SM_OBJID";
                     SEARCH_GENERAL_REQ: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_GENERAL_REQ.BUTTON_SEARCH";
                 }
-                Self::request_lv1(
+                request_lv1(
                     client,
                     TAB_GENERAL_REQ,
                     1,
@@ -262,7 +255,7 @@ impl LectureCategory {
                     GENERAL_OPT_DISCIPLINES: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_GENERAL_OPT.DISCIPLINES";
                     SEARCH_GENERAL_OPT: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_GENERAL_OPT.BUTTON_SEARCH";
                 }
-                Self::request_lv1(
+                request_lv1(
                     client,
                     TAB_GENERAL_OPT,
                     2,
@@ -279,7 +272,7 @@ impl LectureCategory {
                     CHAPEL_TYPE: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_CHAPEL_REQ.SM_OBJID";
                     SEARCH_CHAPEL: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_CHAPEL_REQ.BUTTON_SEARCH";
                 }
-                Self::request_lv1(
+                request_lv1(
                     client,
                     TAB_CHAPEL,
                     3,
@@ -295,7 +288,7 @@ impl LectureCategory {
                     TAB_EDU: TabStripItem<'_> = "ZCMW2100.ID_0001:VIW_MAIN.TAB_EDU";
                     SEARCH_EDU: Button<'_> = "ZCMW2100.ID_0001:VIW_MAIN.BUTTON_EDU";
                 }
-                Self::request(client, TAB_EDU, 4, SEARCH_EDU).await?;
+                request(client, TAB_EDU, 4, SEARCH_EDU).await?;
             }
             LectureCategory::Graduated {
                 collage,
@@ -308,7 +301,7 @@ impl LectureCategory {
                     GRADUATE_DDK_LV4: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_GRADUATE.DDK_LV4";
                     SEARCH_GRADUATE: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_GRADUATE.BUTTON";
                 }
-                Self::request_lv2(
+                request_lv2(
                     client,
                     TAB_GRADUATE,
                     7,
@@ -327,7 +320,7 @@ impl LectureCategory {
                     COMBO_YOMA: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_YOMA.CONNECT_MAJO";
                     SEARCH_YOMA: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_YOMA.BUTTON_SEARCH";
                 }
-                Self::request_lv1(client, TAB_YOMA, 8, COMBO_YOMA, SEARCH_YOMA, major).await?;
+                request_lv1(client, TAB_YOMA, 8, COMBO_YOMA, SEARCH_YOMA, major).await?;
             }
             LectureCategory::UnitedMajor { major } => {
                 // 융합전공
@@ -336,7 +329,7 @@ impl LectureCategory {
                     COMBO_UNMA: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_UNMA.CG_OBJID";
                     SEARCH_UNMA: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_UNMA.BUTTON_SEARCH";
                 }
-                Self::request_lv1(client, TAB_UNMA, 9, COMBO_UNMA, SEARCH_UNMA, major).await?;
+                request_lv1(client, TAB_UNMA, 9, COMBO_UNMA, SEARCH_UNMA, major).await?;
             }
             LectureCategory::FindByProfessor { keyword } => {
                 // 교수명검색
@@ -345,7 +338,7 @@ impl LectureCategory {
                     COMBO_PROFESSOR: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_PROFESSOR.PROFESSOR"; // TODO: implement ComboBoxString
                     SEARCH_PROFESSOR: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_PROFESSOR.BUTTON_SEARCH";
                 }
-                Self::request_text(
+                request_text(
                     client,
                     TAB_PROFESSOR,
                     10,
@@ -362,8 +355,7 @@ impl LectureCategory {
                     COMBO_SEARCH: ComboBox<'_> = "ZCMW2100.ID_0001:VIW_TAB_SEARCH.SEARCH_TEXT";
                     SEARCH_SEARCH: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_SEARCH.BUTTON_SEARCH";
                 }
-                Self::request_text(client, TAB_SEARCH, 11, COMBO_SEARCH, SEARCH_SEARCH, keyword)
-                    .await?;
+                request_text(client, TAB_SEARCH, 11, COMBO_SEARCH, SEARCH_SEARCH, keyword).await?;
             }
             LectureCategory::RecognizedOtherMajor {
                 collage,
@@ -379,7 +371,7 @@ impl LectureCategory {
                     SEARCH_OTHER_GC: Button<'_> = "ZCMW2100.ID_0001:VIW_TAB_OTHER_GC.BTN_OTHER_GC";
                 }
                 if let Some(major) = major {
-                    Self::request_lv3(
+                    request_lv3(
                         client,
                         TAB_OTHER_GC,
                         12,
@@ -393,7 +385,7 @@ impl LectureCategory {
                     )
                     .await?;
                 } else {
-                    Self::request_lv2(
+                    request_lv2(
                         client,
                         TAB_OTHER_GC,
                         12,
@@ -412,131 +404,9 @@ impl LectureCategory {
                     TAB_CYBER: TabStripItem<'_> = "ZCMW2100.ID_0001:VIW_MAIN.TAB_CYBER";
                     SEARCH_CYBER: Button<'_> = "ZCMW2100.ID_0001:VIW_MAIN.BTN_CYBER";
                 }
-                Self::request(client, TAB_CYBER, 14, SEARCH_CYBER).await?;
+                request(client, TAB_CYBER, 14, SEARCH_CYBER).await?;
             }
         }
-        Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn request_lv3(
-        client: &mut WebDynproClient,
-        tab_item: TabStripItemDef,
-        tab_index: u32,
-        lv1: ComboBoxDef,
-        lv2: ComboBoxDef,
-        lv3: ComboBoxDef,
-        search_btn: ButtonDef,
-        value_lv1: &str,
-        value_lv2: &str,
-        value_lv3: &str,
-    ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(
-            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
-        )?;
-        client.process_event(false, tab_select).await?;
-        let lv1_event = ElementParser::new(client.body()).read(
-            ComboBoxSelectByValue1EventCommand::new(lv1, value_lv1, false),
-        )?;
-        client.process_event(false, lv1_event).await?;
-        let lv2_event = ElementParser::new(client.body()).read(
-            ComboBoxSelectByValue1EventCommand::new(lv2, value_lv2, false),
-        )?;
-        client.process_event(false, lv2_event).await?;
-        let parser = ElementParser::new(client.body());
-        let lv3_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
-            lv3, value_lv3, false,
-        ))?;
-        client.process_event(false, lv3_event).await?;
-        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
-        client.process_event(false, btn_press).await?;
-        Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn request_lv2(
-        client: &mut WebDynproClient,
-        tab_item: TabStripItemDef,
-        tab_index: u32,
-        lv1: ComboBoxDef,
-        lv2: ComboBoxDef,
-        search_btn: ButtonDef,
-        value_lv1: &str,
-        value_lv2: &str,
-    ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(
-            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
-        )?;
-        client.process_event(false, tab_select).await?;
-        let lv1_event = ElementParser::new(client.body()).read(
-            ComboBoxSelectByValue1EventCommand::new(lv1, value_lv1, false),
-        )?;
-        client.process_event(false, lv1_event).await?;
-        let parser = ElementParser::new(client.body());
-        let lv2_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
-            lv2, value_lv2, false,
-        ))?;
-        client.process_event(false, lv2_event).await?;
-        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
-        client.process_event(false, btn_press).await?;
-        Ok(())
-    }
-
-    async fn request_lv1(
-        client: &mut WebDynproClient,
-        tab_item: TabStripItemDef,
-        tab_index: u32,
-        lv1: ComboBoxDef,
-        search_btn: ButtonDef,
-        value_lv1: &str,
-    ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(
-            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
-        )?;
-        client.process_event(false, tab_select).await?;
-        let parser = ElementParser::new(client.body());
-        let lv1_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
-            lv1, value_lv1, false,
-        ))?;
-        client.process_event(false, lv1_event).await?;
-        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
-        client.process_event(false, btn_press).await?;
-        Ok(())
-    }
-
-    async fn request_text(
-        client: &mut WebDynproClient,
-        tab_item: TabStripItemDef,
-        tab_index: u32,
-        text_combo: ComboBoxDef,
-        search_btn: ButtonDef,
-        value: &str,
-    ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(
-            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
-        )?;
-        client.process_event(false, tab_select).await?;
-        let parser = ElementParser::new(client.body());
-        let change = parser.read(ComboBoxChangeEventCommand::new(text_combo, value, false))?;
-        client.process_event(false, change).await?;
-        let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
-        client.process_event(false, btn_press).await?;
-        Ok(())
-    }
-
-    async fn request(
-        client: &mut WebDynproClient,
-        tab_item: TabStripItemDef,
-        tab_index: u32,
-        search_btn: ButtonDef,
-    ) -> Result<(), WebDynproError> {
-        let tab_select = ElementParser::new(client.body()).read(
-            TabStripTabSelectEventCommand::new(Self::TABSTRIP, tab_item, tab_index, 0),
-        )?;
-        client.process_event(false, tab_select).await?;
-        let btn_press =
-            ElementParser::new(client.body()).read(ButtonPressEventCommand::new(search_btn))?;
-        client.process_event(false, btn_press).await?;
         Ok(())
     }
 }

--- a/packages/rusaint/src/application/course_schedule/model.rs
+++ b/packages/rusaint/src/application/course_schedule/model.rs
@@ -9,17 +9,11 @@ use crate::application::course_schedule::utils::{
     request, request_lv1, request_lv2, request_lv3, request_text,
 };
 use crate::application::utils::de_with::deserialize_optional_string;
-use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
     define_elements,
     webdynpro::{
         client::WebDynproClient,
-        command::element::{
-            action::ButtonPressEventCommand,
-            layout::TabStripTabSelectEventCommand,
-            selection::{ComboBoxChangeEventCommand, ComboBoxSelectByValue1EventCommand},
-        },
         element::{
             action::Button, complex::sap_table::FromSapTable, definition::ElementDefinition,
             layout::tab_strip::item::TabStripItem, selection::ComboBox,

--- a/packages/rusaint/src/application/course_schedule/utils.rs
+++ b/packages/rusaint/src/application/course_schedule/utils.rs
@@ -1,0 +1,191 @@
+use crate::define_elements;
+use crate::webdynpro::client::{EventProcessResult, WebDynproClient};
+use crate::webdynpro::command::element::action::ButtonPressEventCommand;
+use crate::webdynpro::command::element::layout::TabStripTabSelectEventCommand;
+use crate::webdynpro::command::element::selection::{
+    ComboBoxChangeEventCommand, ComboBoxItemListBoxCommand, ComboBoxSelectByValue1EventCommand,
+    ListBoxItemInfoCommand,
+};
+use crate::webdynpro::command::WebDynproCommandExecutor;
+use crate::webdynpro::element::action::ButtonDef;
+use crate::webdynpro::element::layout::tab_strip::item::TabStripItemDef;
+use crate::webdynpro::element::layout::TabStrip;
+use crate::webdynpro::element::parser::ElementParser;
+use crate::webdynpro::element::selection::list_box::item::ListBoxItemInfo;
+use crate::webdynpro::element::selection::ComboBoxDef;
+use crate::webdynpro::error::WebDynproError;
+
+define_elements! {
+    TABSTRIP: TabStrip<'static> = "ZCMW2100.ID_0001:VIW_MAIN.MODULE_TABSTRIP";
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn request_lv3(
+    client: &mut WebDynproClient,
+    tab_item: TabStripItemDef,
+    tab_index: u32,
+    lv1: ComboBoxDef,
+    lv2: ComboBoxDef,
+    lv3: ComboBoxDef,
+    search_btn: ButtonDef,
+    value_lv1: &str,
+    value_lv2: &str,
+    value_lv3: &str,
+) -> Result<(), WebDynproError> {
+    select_tab(client, tab_item, tab_index).await?;
+    let lv1_event = ElementParser::new(client.body()).read(
+        ComboBoxSelectByValue1EventCommand::new(lv1, value_lv1, false),
+    )?;
+    client.process_event(false, lv1_event).await?;
+    let lv2_event = ElementParser::new(client.body()).read(
+        ComboBoxSelectByValue1EventCommand::new(lv2, value_lv2, false),
+    )?;
+    client.process_event(false, lv2_event).await?;
+    let parser = ElementParser::new(client.body());
+    let lv3_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+        lv3, value_lv3, false,
+    ))?;
+    client.process_event(false, lv3_event).await?;
+    let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
+    client.process_event(false, btn_press).await?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn request_lv2(
+    client: &mut WebDynproClient,
+    tab_item: TabStripItemDef,
+    tab_index: u32,
+    lv1: ComboBoxDef,
+    lv2: ComboBoxDef,
+    search_btn: ButtonDef,
+    value_lv1: &str,
+    value_lv2: &str,
+) -> Result<(), WebDynproError> {
+    select_tab(client, tab_item, tab_index).await?;
+    let lv1_event = ElementParser::new(client.body()).read(
+        ComboBoxSelectByValue1EventCommand::new(lv1, value_lv1, false),
+    )?;
+    client.process_event(false, lv1_event).await?;
+    let parser = ElementParser::new(client.body());
+    let lv2_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+        lv2, value_lv2, false,
+    ))?;
+    client.process_event(false, lv2_event).await?;
+    let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
+    client.process_event(false, btn_press).await?;
+    Ok(())
+}
+
+pub(super) async fn select_lv2(
+    client: &mut WebDynproClient,
+    lv1: ComboBoxDef,
+    lv2: ComboBoxDef,
+    value_lv1: &str,
+    value_lv2: &str,
+) -> Result<(), WebDynproError> {
+    let parser = ElementParser::new(client.body());
+    let lv1_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+        lv1, value_lv1, false,
+    ))?;
+    client.process_event(false, lv1_event).await?;
+    let parser = ElementParser::new(client.body());
+    let lv2_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+        lv2, value_lv2, false,
+    ))?;
+    client.process_event(false, lv2_event).await?;
+    Ok(())
+}
+
+pub(super) async fn request_lv1(
+    client: &mut WebDynproClient,
+    tab_item: TabStripItemDef,
+    tab_index: u32,
+    lv1: ComboBoxDef,
+    search_btn: ButtonDef,
+    value_lv1: &str,
+) -> Result<(), WebDynproError> {
+    select_tab(client, tab_item, tab_index).await?;
+    let parser = ElementParser::new(client.body());
+    let lv1_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+        lv1, value_lv1, false,
+    ))?;
+    client.process_event(false, lv1_event).await?;
+    let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
+    client.process_event(false, btn_press).await?;
+    Ok(())
+}
+
+pub(super) async fn select_lv1(
+    client: &mut WebDynproClient,
+    lv1: ComboBoxDef,
+    value_lv1: &str,
+) -> Result<(), WebDynproError> {
+    let parser = ElementParser::new(client.body());
+    let lv1_event = parser.read(ComboBoxSelectByValue1EventCommand::new(
+        lv1, value_lv1, false,
+    ))?;
+    client.process_event(false, lv1_event).await?;
+    Ok(())
+}
+
+pub(super) async fn request_text(
+    client: &mut WebDynproClient,
+    tab_item: TabStripItemDef,
+    tab_index: u32,
+    text_combo: ComboBoxDef,
+    search_btn: ButtonDef,
+    value: &str,
+) -> Result<(), WebDynproError> {
+    select_tab(client, tab_item, tab_index).await?;
+    let parser = ElementParser::new(client.body());
+    let change = parser.read(ComboBoxChangeEventCommand::new(text_combo, value, false))?;
+    client.process_event(false, change).await?;
+    let btn_press = parser.read(ButtonPressEventCommand::new(search_btn))?;
+    client.process_event(false, btn_press).await?;
+    Ok(())
+}
+
+pub(super) async fn request(
+    client: &mut WebDynproClient,
+    tab_item: TabStripItemDef,
+    tab_index: u32,
+    search_btn: ButtonDef,
+) -> Result<(), WebDynproError> {
+    select_tab(client, tab_item, tab_index).await?;
+    let btn_press =
+        ElementParser::new(client.body()).read(ButtonPressEventCommand::new(search_btn))?;
+    client.process_event(false, btn_press).await?;
+    Ok(())
+}
+
+pub(super) async fn select_tab(
+    client: &mut WebDynproClient,
+    tab_item: TabStripItemDef,
+    tab_index: u32,
+) -> Result<EventProcessResult, WebDynproError> {
+    let tab_select = ElementParser::new(client.body()).read(TabStripTabSelectEventCommand::new(
+        TABSTRIP, tab_item, tab_index, 0,
+    ))?;
+    client.process_event(false, tab_select).await
+}
+
+pub(super) fn combo_box_items(
+    client: &mut WebDynproClient,
+    combo_box: ComboBoxDef,
+) -> Result<Vec<String>, WebDynproError> {
+    let parser = ElementParser::new(client.body());
+    let item_box = parser.read(ComboBoxItemListBoxCommand::new(combo_box))?;
+    parser
+        .read(ListBoxItemInfoCommand::new(item_box))
+        .map(list_box_values)
+}
+
+pub(super) fn list_box_values(vec: Vec<ListBoxItemInfo>) -> Vec<String> {
+    vec.iter()
+        .map(|info| match info {
+            ListBoxItemInfo::Item { value1, .. } => value1.clone(),
+            ListBoxItemInfo::ActionItem { title, .. } => title.clone(),
+        })
+        .collect()
+}

--- a/packages/rusaint/src/application/lecture_assessment/mod.rs
+++ b/packages/rusaint/src/application/lecture_assessment/mod.rs
@@ -2,6 +2,7 @@ use model::LectureAssessmentResult;
 
 use super::{USaintApplication, USaintClient};
 use crate::application::utils::sap_table::try_table_into_with_scroll;
+use crate::application::utils::semester::get_selected_semester;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
@@ -67,6 +68,16 @@ impl<'a> LectureAssessmentApplication {
             SemesterType::Two => "092",
             SemesterType::Winter => "093",
         }
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub fn get_selected_semester(&self) -> Result<(u32, SemesterType), RusaintError> {
+        Ok(get_selected_semester(
+            &self.client,
+            &Self::DDLB_01,
+            &Self::DDLB_02,
+        )?)
     }
 
     fn body(&self) -> &Body {

--- a/packages/rusaint/src/application/lecture_assessment/mod.rs
+++ b/packages/rusaint/src/application/lecture_assessment/mod.rs
@@ -61,8 +61,8 @@ impl<'a> LectureAssessmentApplication {
         TABLE: SapTable<'a> = "ZCMB2W1010.ID_0001:MAIN.TABLE";
     }
 
-    fn semester_to_key(period: SemesterType) -> &'static str {
-        match period {
+    fn semester_to_key(semester: SemesterType) -> &'static str {
+        match semester {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",

--- a/packages/rusaint/src/application/personal_course_schedule/mod.rs
+++ b/packages/rusaint/src/application/personal_course_schedule/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use model::{CourseScheduleInformation, PersonalCourseSchedule, Weekday};
 
 use super::{USaintApplication, USaintClient};
+use crate::application::utils::semester::get_selected_semester;
 use crate::webdynpro::command::WebDynproCommandExecutor;
 use crate::webdynpro::element::parser::ElementParser;
 use crate::{
@@ -78,6 +79,16 @@ impl<'a> PersonalCourseScheduleApplication {
             self.client.process_event(false, event).await?;
         }
         Ok(())
+    }
+
+    /// 현재 페이지에 선택된 년도와 학기를 가져옵니다. 최초 로드 시 현재 학기를 가져올 가능성이 있습니다.
+    /// 하지만 이 애플리케이션의 다른 함수를 호출하여 한번 정보를 가져왔다면 마지막으로 가져온 정보의 학기가 반환되므로 주의하여야 하며, 신뢰할 수 있는 현재 학기의 원천으로 사용되어서는 안됩니다.
+    pub fn get_selected_semester(&self) -> Result<(u32, SemesterType), RusaintError> {
+        Ok(get_selected_semester(
+            &self.client,
+            &Self::PERYR,
+            &Self::PERID,
+        )?)
     }
 
     /// 해당 학기의 시간표 정보를 가져옵니다.

--- a/packages/rusaint/src/application/personal_course_schedule/mod.rs
+++ b/packages/rusaint/src/application/personal_course_schedule/mod.rs
@@ -44,8 +44,8 @@ impl<'a> PersonalCourseScheduleApplication {
         TABLE: SapTable<'a> = "ZCMW2102.ID_0001:VIW_MAIN.TABLE";
     }
 
-    fn semester_to_key(period: SemesterType) -> &'static str {
-        match period {
+    fn semester_to_key(semester: SemesterType) -> &'static str {
+        match semester {
             SemesterType::One => "090",
             SemesterType::Summer => "091",
             SemesterType::Two => "092",

--- a/packages/rusaint/src/application/utils/mod.rs
+++ b/packages/rusaint/src/application/utils/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod de_with;
 pub(crate) mod input_field;
 pub(crate) mod sap_table;
+pub(crate) mod semester;

--- a/packages/rusaint/src/application/utils/semester.rs
+++ b/packages/rusaint/src/application/utils/semester.rs
@@ -1,0 +1,48 @@
+use crate::application::USaintClient;
+use crate::model::SemesterType;
+use crate::webdynpro::command::element::selection::ComboBoxLSDataCommand;
+use crate::webdynpro::command::WebDynproCommandExecutor;
+use crate::webdynpro::element::definition::ElementDefinition;
+use crate::webdynpro::element::parser::ElementParser;
+use crate::webdynpro::element::selection::ComboBoxDef;
+use crate::webdynpro::error::{ElementError, WebDynproError};
+
+pub(crate) fn get_selected_semester(
+    client: &USaintClient,
+    year_def: &ComboBoxDef,
+    semester_def: &ComboBoxDef,
+) -> Result<(u32, SemesterType), WebDynproError> {
+    let parser = ElementParser::new(client.body());
+    let year = parser
+        .read(ComboBoxLSDataCommand::new(year_def.clone()))?
+        .key()
+        .ok_or_else(|| {
+            WebDynproError::Element(ElementError::NoSuchContent {
+                element: year_def.id().to_string(),
+                content: "No data provided".to_string(),
+            })
+        })?
+        .parse::<u32>()
+        .or(Err(WebDynproError::Element(ElementError::InvalidContent {
+            element: year_def.id().to_string(),
+            content: "Year cannot be parsed as u32".to_string(),
+        })))?;
+    let semester = match parser
+        .read(ComboBoxLSDataCommand::new(semester_def.clone()))?
+        .key()
+        .ok_or_else(|| {
+            WebDynproError::Element(ElementError::NoSuchContent {
+                element: semester_def.id().to_string(),
+                content: "No data provided".to_string(),
+            })
+        })?
+        .as_str()
+    {
+        "090" => SemesterType::One,
+        "091" => SemesterType::Summer,
+        "092" => SemesterType::Two,
+        "093" => SemesterType::Winter,
+        _ => unreachable!("Invalid semester key"),
+    };
+    Ok((year, semester))
+}

--- a/packages/rusaint/src/webdynpro/element/selection/list_box/mod.rs
+++ b/packages/rusaint/src/webdynpro/element/selection/list_box/mod.rs
@@ -159,20 +159,27 @@ macro_rules! def_listbox_subset {
 
     /// [`ListBox`] 분류의 엘리먼트를 위한 공통된 Wrapper
     #[derive(Debug)]
-    pub enum ListBoxWrapper<'a> {
+    pub enum ListBoxWrapper<'body> {
         $(
             $(#[$attr])*
-            $name($name<'a>),
+            $name($name<'body>),
         )+
     }
 
-    impl<'a> ListBoxWrapper<'a> {
+    impl<'body> ListBoxWrapper<'body> {
 
         /// [`ElementWrapper`](crate::webdynpro::element::ElementWrapper)에서 [`ListBoxWrapper`](ListBoxWrapper)로 변환을 시도합니다.
-        pub fn from_elements(elements: $crate::webdynpro::element::ElementWrapper<'a>) -> Option<ListBoxWrapper<'a>> {
+        pub fn from_elements(elements: $crate::webdynpro::element::ElementWrapper<'body>) -> Option<ListBoxWrapper<'body>> {
             match elements {
                 $($crate::webdynpro::element::ElementWrapper::$name(elem) => Some(ListBoxWrapper::$name(elem)),)+
                 _ => None
+            }
+        }
+
+        /// 해당 [`ListBoxWrapper`]의 원본 [`ListBox`]를 반환합니다.
+        pub fn unwrap(&'body self) -> &'body $crate::webdynpro::element::selection::list_box::ListBox<'body> {
+            match self {
+                $(ListBoxWrapper::$name(elem) => elem.list_box(),)+
             }
         }
     }


### PR DESCRIPTION
# What's in this pull request
- 현재 선택되어 있는 학기(년도, 학기)를 가져오는 `get_selected_semester` 메소드를 학기 선택 기능이 있는 애플리케이션에 추가
- `CourseScheduleApplication`에서 각 선택 항목들을 불러올 수 있는 함수 추가(단과대 목록, 선택 과목 목록 등, closes #168)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added semester selection utility across multiple application modules.
  - Enhanced course schedule exploration with new retrieval methods for collages, departments, majors, and categories.
  - Introduced new methods to retrieve the currently selected semester in various application components.

- **Improvements**
  - Standardized semester parameter naming across various application methods.
  - Improved error handling for semester and year selection.
  - Refined WebDynpro element handling for list box and combo box interactions.

- **Chores**
  - Updated `.gitignore` to exclude IDE and build system files.
  - Refactored internal utility functions for more modular code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->