### PR TITLE
[ci] 이미 빌드가 진행 중인 경우 취소하지 않고 대기

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["dev"]
+    branches: [ "dev" ]
   schedule:
     - cron: "23 3 * * *"
 env:
@@ -14,7 +14,6 @@ jobs:
     environment: testing
     concurrency:
       group: testing
-      cancel-in-progress: true
     env:
       SSO_ID: ${{ vars.SSO_ID }}
       SSO_PASSWORD: ${{ secrets.SSO_PASSWORD }}


### PR DESCRIPTION
# What's in this pull request
- `build-test` 워크플로가 실행 중일 때 새로운 잡이 요청되었을 경우 기존 잡을 취소하지 않고 대기