### PR TITLE
[chore] `dev` 브랜치 삭제

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,9 +9,9 @@ reviews:
   review_status: true
   collapse_walkthrough: false
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
-      - "dev"
+      - "main"
 chat:
   auto_reply: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "main" ]
   schedule:
     - cron: "23 3 * * *"
 env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["dev"]
+    branches: [ "dev" ]
   schedule:
     - cron: "23 3 * * *"
 env:
@@ -14,7 +14,6 @@ jobs:
     environment: testing
     concurrency:
       group: testing
-      cancel-in-progress: true
     env:
       SSO_ID: ${{ vars.SSO_ID }}
       SSO_PASSWORD: ${{ secrets.SSO_PASSWORD }}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -3,6 +3,8 @@ name: Dry-run before publish
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'Cargo.toml'
 env:
   CARGO_TERM_COLOR: always
 jobs:
@@ -11,7 +13,6 @@ jobs:
     environment: testing
     concurrency:
       group: testing
-      cancel-in-progress: true
     env:
       SSO_ID: ${{ vars.SSO_ID }}
       SSO_PASSWORD: ${{ secrets.SSO_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["main", "dev"]
+    branches: [ "main" ]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -108,7 +108,7 @@ jobs:
             --out-dir $RUNNER_TEMP/bindings
       - name: Compress generated swift bindings
         run: |
-          tar -czvf $RUNNER_TEMP/bindings.tar.gz $RUNNER_TEMP/bindings
+          tar -czvf $RUNNER_TEMP/bindings.tar.gz $RUNNER_TEMP/bindings/*.swift
       - name: Massage the generated files to fit xcframework
         run: |
           mkdir $RUNNER_TEMP/Headers
@@ -136,12 +136,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rusaint-ios-bindings
-          path: $RUNNER_TEMP/bindings.tar.gz
+          path: ${{ runner.temp }}/bindings.tar.gz
       - name: Upload xcframework
         uses: actions/upload-artifact@v4
         with:
           name: RusaintFFI.xcframework
-          path: $RUNNER_TEMP/RusaintFFI.xcframework.tar.gz
+          path: ${{ runner.temp }}/RusaintFFI.xcframework.tar.gz
   release-ios:
     runs-on: ubuntu-latest
     needs: build-ios
@@ -156,12 +156,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rusaint-ios-bindings
-          path: $RUNNER_TEMP/bindings.tar.gz
+          path: ${{ runner.temp }}
       - name: Download xcframework
         uses: actions/download-artifact@v4
         with:
           name: RusaintFFI.xcframework
-          path: $RUNNER_TEMP/RusaintFFI.xcframework.tar.gz
+          path: ${{ runner.temp }}
       - name: Extract bindings
         run: |
           rm -rf Sources/Rusaint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["packages/rusaint", "packages/rusaint-ffi", "uniffi-bindgen"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4-dev.0"
+version = "0.8.4"
 
 keywords = ["ssu", "u-saint", "scraping", "parser"]
 authors = ["Hyomin Koo <me@eatsteak.dev>"]

--- a/languages/kotlin/lib/build.gradle.kts
+++ b/languages/kotlin/lib/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 group = "dev.eatsteak"
 description = "Easy and Reliable SSU u-saint scraper"
-version = "0.8.4-dev.0"
+version = "0.8.4"
 
 android {
     namespace = "dev.eatsteak.rusaint"


### PR DESCRIPTION
# What's in this pull request
- 릴리즈 워크플로가 버전을 확인하게 되면서 브랜치 분리의 이유가 없어짐
- 정상적인 changelog 생성을 위해서도 dev 브랜치 삭제 필요