### PR TITLE
[fix] `CODECOV_TOKEN`이 없는 경우 커버리지 업로드 방지

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# What's in this pull request
- `CODECOV_TOKEN` 시크릿이 없는 경우 커버리지 업로드를 진행하지 않도록 합니다.
  - 포크된 저장소에서 액션 실패를 방지합니다.