### PR TITLE
[fix] SemesterGrade, ClassGrade의 year와 semester 타입을 각각 `u32`와 `SemesterType`으로 통일

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use futures::executor::block_on;
 // 성적 정보를 출력하는 애플리케이션
 fn main() {
     block_on(print_grades());
-    /* SemesterSummary { year: 2022, semester: "2 학기", attempted_credits: 17.5, earned_credits: 17.5, pf_earned_credits: 0.5, grade_points_avarage: 4.5, grade_points_sum: 100.0, arithmetic_mean: 100.0, semester_rank: (1, 99), general_rank: (1, 99), academic_probation: false, consult: false, flunked: false }
+    /* SemesterSummary { year: 2022, semester: "2 학기", attempted_credits: 17.5, earned_credits: 17.5, pf_earned_credits: 0.5, grade_points_average: 4.5, grade_points_sum: 100.0, arithmetic_mean: 100.0, semester_rank: (1, 99), general_rank: (1, 99), academic_probation: false, consult: false, flunked: false }
      * ...
      */
 }

--- a/packages/rusaint/src/application/course_grades/mod.rs
+++ b/packages/rusaint/src/application/course_grades/mod.rs
@@ -407,12 +407,12 @@ impl<'a> CourseGradesApplication {
         semester: SemesterType,
         include_details: bool,
     ) -> Result<Vec<ClassGrade>, RusaintError> {
-        let year = year.to_string();
         {
             self.close_popups().await?;
             let parser = ElementParser::new(self.client.body());
             self.select_course(&parser, course_type).await?;
-            self.select_semester(&parser, &year, semester).await?;
+            self.select_semester(&parser, &year.to_string(), semester)
+                .await?;
         }
         let parser = ElementParser::new(self.client.body());
         let class_grades: Vec<(Option<Event>, HashMap<String, String>)> = {
@@ -451,8 +451,8 @@ impl<'a> CourseGradesApplication {
             };
             let parsed: Option<ClassGrade> = (|| {
                 Some(ClassGrade::new(
-                    year.to_owned(),
-                    semester.to_string(),
+                    year,
+                    semester,
                     values["과목코드"].trim().to_owned(),
                     values["과목명"].trim().to_owned(),
                     values["과목학점"].parse().ok()?,

--- a/packages/rusaint/src/application/course_grades/model.rs
+++ b/packages/rusaint/src/application/course_grades/model.rs
@@ -30,7 +30,7 @@ pub struct GradeSummary {
     /// 평점계
     grade_points_sum: f32,
     /// 평점평균
-    grade_points_avarage: f32,
+    grade_points_average: f32,
     /// 산술평균
     arithmetic_mean: f32,
     /// P/F 학점계
@@ -49,7 +49,7 @@ impl GradeSummary {
             attempted_credits,
             earned_credits,
             grade_points_sum: gpa,
-            grade_points_avarage: cgpa,
+            grade_points_average: cgpa,
             arithmetic_mean: avg,
             pf_earned_credits,
         }
@@ -71,8 +71,8 @@ impl GradeSummary {
     }
 
     /// 평점평균
-    pub fn grade_points_avarage(&self) -> f32 {
-        self.grade_points_avarage
+    pub fn grade_points_average(&self) -> f32 {
+        self.grade_points_average
     }
 
     /// 산술평균
@@ -126,7 +126,7 @@ pub struct SemesterGrade {
         rename(deserialize = "평점평균"),
         deserialize_with = "deserialize_f32_string"
     )]
-    grade_points_avarage: f32,
+    grade_points_average: f32,
     /// 평점계
     #[serde(
         rename(deserialize = "평점계"),
@@ -211,8 +211,8 @@ impl SemesterGrade {
     }
 
     /// 평점평균
-    pub fn grade_points_avarage(&self) -> f32 {
-        self.grade_points_avarage
+    pub fn grade_points_average(&self) -> f32 {
+        self.grade_points_average
     }
 
     /// 평점계

--- a/packages/rusaint/src/application/course_grades/model.rs
+++ b/packages/rusaint/src/application/course_grades/model.rs
@@ -5,13 +5,17 @@ use serde::{
     Deserialize, Deserializer, Serialize,
 };
 
-use crate::application::utils::de_with::{
-    deserialize_empty, deserialize_f32_string, deserialize_u32_string,
-};
 use crate::webdynpro::element::parser::ElementParser;
 use crate::webdynpro::{
     element::{complex::sap_table::FromSapTable, definition::ElementDefinition},
     error::{ElementError, WebDynproError},
+};
+use crate::{
+    application::utils::de_with::{
+        deserialize_empty, deserialize_f32_string, deserialize_semester_type,
+        deserialize_u32_string,
+    },
+    model::SemesterType,
 };
 
 /// 전체 성적(학적부, 증명)
@@ -94,8 +98,11 @@ pub struct SemesterGrade {
     )]
     year: u32,
     /// 학기
-    #[serde(rename(deserialize = "학기"))]
-    semester: String,
+    #[serde(
+        rename(deserialize = "학기"),
+        deserialize_with = "deserialize_semester_type"
+    )]
+    semester: SemesterType,
     /// 신청학점
     #[serde(
         rename(deserialize = "신청학점"),
@@ -189,8 +196,8 @@ impl SemesterGrade {
     }
 
     /// 학기
-    pub fn semester(&self) -> &str {
-        self.semester.as_ref()
+    pub fn semester(&self) -> SemesterType {
+        self.semester
     }
 
     /// 취득학점
@@ -267,9 +274,9 @@ impl<'body> FromSapTable<'body> for SemesterGrade {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ClassGrade {
     /// 이수학년도
-    year: String,
+    year: u32,
     /// 이수학기
-    semester: String,
+    semester: SemesterType,
     /// 과목코드
     code: String,
     /// 과목명
@@ -289,8 +296,8 @@ pub struct ClassGrade {
 impl ClassGrade {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        year: String,
-        semester: String,
+        year: u32,
+        semester: SemesterType,
         code: String,
         class_name: String,
         grade_points: f32,
@@ -313,13 +320,13 @@ impl ClassGrade {
     }
 
     /// 이수학년도
-    pub fn year(&self) -> &str {
-        self.year.as_ref()
+    pub fn year(&self) -> u32 {
+        self.year
     }
 
     /// 이수학기
-    pub fn semester(&self) -> &str {
-        self.semester.as_ref()
+    pub fn semester(&self) -> SemesterType {
+        self.semester
     }
 
     /// 과목코드

--- a/packages/rusaint/src/lib.rs
+++ b/packages/rusaint/src/lib.rs
@@ -32,7 +32,7 @@
 //! // 성적 정보를 출력하는 애플리케이션
 //! fn main() {
 //!     block_on(print_grades());
-//!     /* SemesterGrade { year: 2022, semester: "2 학기", attempted_credits: 17.5, earned_credits: 17.5, pf_earned_credits: 0.5, grade_points_avarage: 4.5, grade_points_sum: 100.0, arithmetic_mean: 100.0, semester_rank: (1, 99), general_rank: (1, 99), academic_probation: false, consult: false, flunked: false }
+//!     /* SemesterGrade { year: 2022, semester: "2 학기", attempted_credits: 17.5, earned_credits: 17.5, pf_earned_credits: 0.5, grade_points_average: 4.5, grade_points_sum: 100.0, arithmetic_mean: 100.0, semester_rank: (1, 99), general_rank: (1, 99), academic_probation: false, consult: false, flunked: false }
 //!      */
 //! }
 //!


### PR DESCRIPTION
- SemesterGrade, ClassGrade의 year와 semester 타입을 각각 u32와 SemesterType으로 통일
- `avarage`오타를 `average`로 수정

전체적으로 검토하긴 했지만 SemesterGrade, ClassGrade 외에 year와 semester의 타입이 다른 모델이 또 있다면 알려주세요!