### PR TITLE
[fix] SemesterType 역직렬화 오류 수정

### DIFF
--- a/packages/rusaint/src/application/utils/de_with.rs
+++ b/packages/rusaint/src/application/utils/de_with.rs
@@ -55,10 +55,10 @@ pub(crate) fn deserialize_semester_type<'de, D: Deserializer<'de>>(
     let value = String::deserialize(deserializer)?;
     match value.trim() {
         "1 학기" => Ok(SemesterType::One),
-        "여름 학기" => Ok(SemesterType::Summer),
+        "여름학기" | "여름 학기" => Ok(SemesterType::Summer),
         "2 학기" => Ok(SemesterType::Two),
-        "겨울 학기" => Ok(SemesterType::Winter),
-        _ => Err(serde::de::Error::custom("Unknown SemesterType varient")),
+        "겨울학기" | "겨울 학기" => Ok(SemesterType::Winter),
+        _ => Err(serde::de::Error::custom("Unknown SemesterType variant")),
     }
 }
 


### PR DESCRIPTION
# What's in this pull request
- SemesterType이 `CourseGradesApplication::semesters` 함수에서 역직렬화 되지 않는 문제 수정