### PR TITLE
[fix] 채플 정보 조회에서 일부 정보가 제대로 표기되지 않는 문제 해결

### DIFF
--- a/packages/rusaint/src/webdynpro/element/mod.rs
+++ b/packages/rusaint/src/webdynpro/element/mod.rs
@@ -371,6 +371,10 @@ impl ElementWrapper<'_> {
             ElementWrapper::TextView(tv) => Ok(tv.text().to_string()),
             ElementWrapper::Caption(cp) => Ok(cp.text().to_string()),
             ElementWrapper::CheckBox(c) => Ok(format!("{}", c.checked())),
+            ElementWrapper::ComboBox(cb) => Ok(cb.value().unwrap_or_default().to_string()),
+            ElementWrapper::InputField(ifield) => {
+                Ok(ifield.value().unwrap_or_default().to_string())
+            }
             _ => Err(WebDynproError::Element(ElementError::InvalidContent {
                 element: self.id().to_string(),
                 content: "This element is cannot be textised.".to_string(),


### PR DESCRIPTION
# What's in this pull request
- `ComboBox`와 `InputField`를 `ElementWrapper::textise` 함수에 추가하여 텍스트로 올바르게 변환될 수 있도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced text extraction capabilities to support ComboBox and InputField elements, allowing their values to be retrieved as text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->