### PR TITLE
[fix] `SemesterType` 역직렬화에 실패하는 문제 수정

### DIFF
--- a/packages/rusaint/src/application/utils/de_with.rs
+++ b/packages/rusaint/src/application/utils/de_with.rs
@@ -54,9 +54,9 @@ pub(crate) fn deserialize_semester_type<'de, D: Deserializer<'de>>(
 ) -> Result<SemesterType, D::Error> {
     let value = String::deserialize(deserializer)?;
     match value.trim() {
-        "1 학기" => Ok(SemesterType::One),
+        "1 학기" | "1학기" => Ok(SemesterType::One),
         "여름학기" | "여름 학기" => Ok(SemesterType::Summer),
-        "2 학기" => Ok(SemesterType::Two),
+        "2 학기" | "2학기" => Ok(SemesterType::Two),
         "겨울학기" | "겨울 학기" => Ok(SemesterType::Winter),
         _ => Err(serde::de::Error::custom("Unknown SemesterType variant")),
     }


### PR DESCRIPTION
- 채플, 성적 정보에서 학기 명이 `1 학기` -> `1학기` 로 변경되면서 발생한 역직렬화 오류 수정