### PR TITLE
[refactor] `log`를 `tracing`으로 대체

### DIFF
--- a/packages/rusaint/Cargo.toml
+++ b/packages/rusaint/Cargo.toml
@@ -44,6 +44,7 @@ log = { version = "0.4.27", features = ["kv"] }
 serde_json = "1.0.140"
 reqwest_cookie_store = { version = "0.8.0", features = ["serde"] }
 cookie_store = "0.21.1"
+tracing = "0.1.41"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/packages/rusaint/Cargo.toml
+++ b/packages/rusaint/Cargo.toml
@@ -40,7 +40,6 @@ scraper = { version = "0.23.1", features = ["atomic"], optional = true }
 serde = { version = "1", features = ["derive"] }
 custom_debug_derive = "0.6.2"
 regex-lite = "0.1.6"
-log = { version = "0.4.27", features = ["kv"] }
 serde_json = "1.0.140"
 reqwest_cookie_store = { version = "0.8.0", features = ["serde"] }
 cookie_store = "0.21.1"
@@ -54,7 +53,7 @@ futures = "0.3.31"
 tokio-test = "0.4.4"
 tokio = { workspace = true, features = ["macros", "test-util"] }
 lazy_static = "1.5.0"
-test-log = "0.2.17"
+tracing-test = "0.2.5"
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/packages/rusaint/src/application/utils/input_field.rs
+++ b/packages/rusaint/src/application/utils/input_field.rs
@@ -16,7 +16,7 @@ impl InputField<'_> {
 
     pub(crate) fn value_into_u32(&self) -> Result<u32, WebDynproError> {
         self.value_string()?.trim().parse::<u32>().map_err(|e| {
-            log::error!(e:?; "failed to convert string to u32");
+            tracing::error!(?e, "failed to convert string to u32");
             ElementError::InvalidContent {
                 element: self.id().to_owned(),
                 content: "value is not correct u32".to_string(),

--- a/packages/rusaint/src/lib.rs
+++ b/packages/rusaint/src/lib.rs
@@ -113,10 +113,10 @@ pub mod global_test_utils {
         let session_file_path =
             std::env::var("SSO_SESSION_FILE").unwrap_or("session.json".to_string());
         let f = File::open(&session_file_path)
-            .map_err(|e| Error::msg(format!("Failed to open session file: {}", e)))?;
+            .map_err(|e| Error::msg(format!("Failed to open session file: {e}")))?;
         let reader = BufReader::new(f);
         let session: USaintSession = USaintSession::from_json(reader)
-            .map_err(|e| Error::msg(format!("Failed to parse session file: {}", e)))?;
+            .map_err(|e| Error::msg(format!("Failed to parse session file: {e}")))?;
         let session = Arc::new(session);
         Ok(session)
     }

--- a/packages/rusaint/src/session/mod.rs
+++ b/packages/rusaint/src/session/mod.rs
@@ -88,7 +88,7 @@ impl USaintSession {
                 )
                 .unwrap();
         } else {
-            log::warn!("WAF cookie not found in portal response");
+            tracing::warn!("WAF cookie not found in portal response");
         }
         let token_cookie_str = format!("sToken={token}; domain=.ssu.ac.kr; path=/; secure");
         let req = client

--- a/packages/rusaint/src/webdynpro/client/body/mod.rs
+++ b/packages/rusaint/src/webdynpro/client/body/mod.rs
@@ -103,7 +103,7 @@ impl BodyUpdate {
                         );
                     }
                     &_ => {
-                        log::warn!("Unknown body update {tag_name} is found, ignore.");
+                        tracing::warn!("Unknown body update {tag_name} is found, ignore.");
                     }
                 };
             }

--- a/packages/rusaint/src/webdynpro/client/mod.rs
+++ b/packages/rusaint/src/webdynpro/client/mod.rs
@@ -157,7 +157,7 @@ impl WebDynproClient {
             .send()
             .await?;
         if !res.status().is_success() {
-            log::warn!(res:?, serialized_events:%; "event request failed: {}", &serialized_events);
+            tracing::warn!(?res, %serialized_events, "event request failed: {}", &serialized_events);
             return Err(ClientError::InvalidResponse(res))?;
         }
         Ok(res.text().await?)

--- a/packages/rusaint/src/webdynpro/element/definition/mod.rs
+++ b/packages/rusaint/src/webdynpro/element/definition/mod.rs
@@ -45,7 +45,7 @@ pub trait ElementDefinition<'body>: Sized {
     fn selector(&self) -> Result<Selector, WebDynproError> {
         Ok(
             Selector::parse(format!(r#"[id="{}"]"#, self.id()).as_str()).map_err(|err| {
-                log::warn!(err:?; "failed to parse selector");
+                tracing::warn!(?err, "failed to parse selector");
                 BodyError::InvalidSelector
             })?,
         )

--- a/packages/rusaint/src/webdynpro/element/macros.rs
+++ b/packages/rusaint/src/webdynpro/element/macros.rs
@@ -109,10 +109,10 @@ macro_rules! define_element_base {
                 self.lsdata
                     .get_or_init(|| {
                         let lsdata_attr = self.element_ref.value().attr("lsdata").unwrap_or("");
-                        let Ok(lsdata_obj) = $crate::webdynpro::element::utils::parse_lsdata(lsdata_attr).or_else(|e| { log::warn!(e:?; "failed to parse lsdata"); Err(e) }) else {
+                        let Ok(lsdata_obj) = $crate::webdynpro::element::utils::parse_lsdata(lsdata_attr).or_else(|e| { tracing::warn!(?e, "failed to parse lsdata"); Err(e) }) else {
                             return $lsdata::default();
                         };
-                        serde_json::from_value::<Self::ElementLSData>(lsdata_obj).or_else(|e| { log::warn!(e:?; "failed to convert lsdata to struct"); Err(e) }).ok().unwrap_or($lsdata::default())
+                        serde_json::from_value::<Self::ElementLSData>(lsdata_obj).or_else(|e| { tracing::warn!(?e, "failed to convert lsdata to struct"); Err(e) }).ok().unwrap_or($lsdata::default())
                     })
             }
 
@@ -190,7 +190,7 @@ macro_rules! define_element_interactable {
                 self.lsevents
                     .get_or_init(|| {
                         let lsevents_attr = self.element_ref.value().attr("lsevents").unwrap_or("");
-                        $crate::webdynpro::element::utils::parse_lsevents(lsevents_attr).or_else(|e| { log::warn!(e:?; "failed to parse lsevents"); Err(e) }).ok()
+                        $crate::webdynpro::element::utils::parse_lsevents(lsevents_attr).or_else(|e| { tracing::warn!(?e, "failed to parse lsevents"); Err(e) }).ok()
                     })
                     .as_ref()
             }

--- a/packages/rusaint/src/webdynpro/element/selection/list_box/mod.rs
+++ b/packages/rusaint/src/webdynpro/element/selection/list_box/mod.rs
@@ -79,7 +79,7 @@ macro_rules! def_listbox_subset {
                 self.list_box().lsdata
                     .get_or_init(|| {
                         let lsdata_attr = self.element_ref().value().attr("lsdata").unwrap_or("");
-                        let Ok(lsdata_obj) = $crate::webdynpro::element::utils::parse_lsdata(lsdata_attr).or_else(|e| { log::warn!(e:?; "failed to parse lsdata"); Err(e) }) else {
+                        let Ok(lsdata_obj) = $crate::webdynpro::element::utils::parse_lsdata(lsdata_attr).or_else(|e| { tracing::warn!(?e, "failed to parse lsdata"); Err(e) }) else {
                             return ListBoxLSData::default();
                         };
                         serde_json::from_value::<Self::ElementLSData>(lsdata_obj).unwrap_or(ListBoxLSData::default())
@@ -112,7 +112,7 @@ macro_rules! def_listbox_subset {
                 self.list_box().lsevents
                     .get_or_init(|| {
                         let lsevents_attr = self.list_box().element_ref.value().attr("lsevents").unwrap_or("");
-                        $crate::webdynpro::element::utils::parse_lsevents(lsevents_attr).or_else(|e| { log::warn!(e:?; "failed to parse lseventscargo b"); Err(e) }).ok()
+                        $crate::webdynpro::element::utils::parse_lsevents(lsevents_attr).or_else(|e| { tracing::warn!(?e, "failed to parse lsevents"); Err(e) }).ok()
                     })
                     .as_ref()
             }

--- a/packages/rusaint/src/webdynpro/element/sub/definition.rs
+++ b/packages/rusaint/src/webdynpro/element/sub/definition.rs
@@ -37,7 +37,7 @@ pub trait SubElementDefinition<'body>: Sized {
     fn selector(&self) -> Result<Selector, WebDynproError> {
         Selector::parse(format!(r#"[id="{}"] [id="{}"]"#, self.parent().id(), self.id()).as_str())
             .or_else(|e| {
-                log::warn!(e:?; "failed to parse selector");
+                tracing::warn!(?e, "failed to parse selector");
                 Err(ElementError::InvalidId(format!(
                     "{}, {}",
                     self.parent().id(),

--- a/packages/rusaint/tests/application/chapel.rs
+++ b/packages/rusaint/tests/application/chapel.rs
@@ -6,8 +6,8 @@ use rusaint::{
     application::{USaintClientBuilder, chapel::ChapelApplication},
 };
 use std::sync::{Arc, OnceLock};
-use test_log::test;
 use tokio::sync::{Mutex, RwLock};
+use tracing_test::traced_test;
 
 lazy_static! {
     static ref APP: Mutex<OnceLock<Arc<RwLock<ChapelApplication>>>> = Mutex::new(OnceLock::new());
@@ -31,7 +31,8 @@ async fn get_app() -> Result<Arc<RwLock<ChapelApplication>>, RusaintError> {
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn chapel() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -39,10 +40,11 @@ async fn chapel() {
         .information(*TARGET_YEAR, *TARGET_SEMESTER)
         .await
         .unwrap();
-    println!("{:?}", info);
+    tracing::info!("{:?}", info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn no_chapel() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -51,6 +53,6 @@ async fn no_chapel() {
         info,
         RusaintError::ApplicationError(ApplicationError::NoChapelInformation)
     ));
-    println!("{:?}", info);
-    println!("{:?}", info);
+    tracing::info!("{:?}", info);
+    tracing::info!("{:?}", info);
 }

--- a/packages/rusaint/tests/application/course_grades.rs
+++ b/packages/rusaint/tests/application/course_grades.rs
@@ -6,8 +6,8 @@ use rusaint::application::{
     course_grades::{CourseGradesApplication, model::CourseType},
 };
 use std::sync::{Arc, OnceLock};
-use test_log::test;
 use tokio::sync::{Mutex, RwLock};
+use tracing_test::traced_test;
 
 lazy_static! {
     static ref APP: Mutex<OnceLock<Arc<RwLock<CourseGradesApplication>>>> =
@@ -32,20 +32,22 @@ async fn get_app() -> Result<Arc<RwLock<CourseGradesApplication>>, RusaintError>
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn recorded_summary() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let recorded_summary = app.recorded_summary(CourseType::Bachelor).await.unwrap();
-    println!("Recorded: {:?}", recorded_summary);
+    tracing::info!("Recorded: {:?}", recorded_summary);
     let certificated_summary = app
         .certificated_summary(CourseType::Bachelor)
         .await
         .unwrap();
-    println!("Certificated: {:?}", certificated_summary);
+    tracing::info!("Certificated: {:?}", certificated_summary);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn certificated_summary() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -53,19 +55,21 @@ async fn certificated_summary() {
         .certificated_summary(CourseType::Bachelor)
         .await
         .unwrap();
-    println!("Certificated: {:?}", certificated_summary);
+    tracing::info!("Certificated: {:?}", certificated_summary);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn semesters() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let semesters = app.semesters(CourseType::Bachelor).await.unwrap();
-    println!("{:?}", semesters);
+    tracing::info!("{:?}", semesters);
     assert!(!semesters.is_empty());
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn classes_with_detail() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -73,12 +77,12 @@ async fn classes_with_detail() {
         .classes(CourseType::Bachelor, *TARGET_YEAR, *TARGET_SEMESTER, true)
         .await
         .unwrap();
-    println!("{:?}", details);
+    tracing::info!("{:?}", details);
     assert!(!details.is_empty());
-    println!("Try to obtain class's detail");
+    tracing::info!("Try to obtain class's detail");
     let detail_code = details.iter().find(|grade| grade.detail().is_some());
     if detail_code.is_none() {
-        println!("No class found with detail");
+        tracing::info!("No class found with detail");
         return;
     }
     let detail_code = detail_code.unwrap();
@@ -91,6 +95,6 @@ async fn classes_with_detail() {
         )
         .await
         .unwrap();
-    println!("{:?}", detail);
+    tracing::info!("{:?}", detail);
     assert!(!detail.is_empty());
 }

--- a/packages/rusaint/tests/application/course_schedule.rs
+++ b/packages/rusaint/tests/application/course_schedule.rs
@@ -9,8 +9,8 @@ use rusaint::{
     model::SemesterType,
 };
 use std::sync::{Arc, OnceLock};
-use test_log::test;
 use tokio::sync::{Mutex, RwLock};
+use tracing_test::traced_test;
 
 lazy_static! {
     static ref APP: Mutex<OnceLock<Arc<RwLock<CourseScheduleApplication>>>> =
@@ -35,7 +35,8 @@ async fn get_app() -> Result<Arc<RwLock<CourseScheduleApplication>>, RusaintErro
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_major() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -45,11 +46,12 @@ async fn find_major() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_required_elective() {
     let session = get_session().await.unwrap().clone();
     let mut app = USaintClientBuilder::new()
@@ -63,11 +65,12 @@ async fn find_required_elective() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_optional_elective() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -77,11 +80,12 @@ async fn find_optional_elective() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_chapel() {
     let session = get_session().await.unwrap().clone();
     let mut app = USaintClientBuilder::new()
@@ -95,11 +99,12 @@ async fn find_chapel() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_education() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -109,12 +114,12 @@ async fn find_education() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
 #[tokio::test]
-#[ignore]
+#[traced_test]
 async fn find_graduated() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -124,11 +129,12 @@ async fn find_graduated() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_connected_major() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -138,11 +144,12 @@ async fn find_connected_major() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_united_major() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -152,11 +159,12 @@ async fn find_united_major() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_recognized_other_major() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -166,11 +174,12 @@ async fn find_recognized_other_major() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_cyber() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -180,11 +189,12 @@ async fn find_cyber() {
         .await
         .unwrap();
     for lecture in lectures {
-        println!("{:?}", lecture);
+        tracing::info!("{:?}", lecture);
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn find_nothing() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;

--- a/packages/rusaint/tests/application/graduation_requirements.rs
+++ b/packages/rusaint/tests/application/graduation_requirements.rs
@@ -5,8 +5,8 @@ use rusaint::application::{
     USaintClientBuilder, graduation_requirements::GraduationRequirementsApplication,
 };
 use std::sync::{Arc, OnceLock};
-use test_log::test;
 use tokio::sync::{Mutex, RwLock};
+use tracing_test::traced_test;
 
 lazy_static! {
     static ref APP: Mutex<OnceLock<Arc<RwLock<GraduationRequirementsApplication>>>> =
@@ -31,18 +31,20 @@ async fn get_app() -> Result<Arc<RwLock<GraduationRequirementsApplication>>, Rus
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn student_info() {
     let lock = get_app().await.unwrap();
     let app = lock.read().await;
     let student_info = app.student_info().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn graduation_requirements() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let graduation_requirements = app.requirements().await.unwrap();
-    println!("{:?}", graduation_requirements);
+    tracing::info!("{:?}", graduation_requirements);
 }

--- a/packages/rusaint/tests/application/lecture_assessment.rs
+++ b/packages/rusaint/tests/application/lecture_assessment.rs
@@ -3,9 +3,10 @@ use rusaint::{
     application::{USaintClientBuilder, lecture_assessment::LectureAssessmentApplication},
     model::SemesterType,
 };
-use test_log::test;
+use tracing_test::traced_test;
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn lecture_assessment() {
     let session = get_session().await.unwrap().clone();
     let mut app = USaintClientBuilder::new()
@@ -18,5 +19,5 @@ async fn lecture_assessment() {
         .await
         .unwrap();
     assert_eq!(info.len(), 29);
-    println!("{} results: {:?}", info.len(), info);
+    tracing::info!("{} results: {:?}", info.len(), info);
 }

--- a/packages/rusaint/tests/application/personal_course_schedule.rs
+++ b/packages/rusaint/tests/application/personal_course_schedule.rs
@@ -8,8 +8,8 @@ use rusaint::{
     },
 };
 use std::sync::{Arc, OnceLock};
-use test_log::test;
 use tokio::sync::{Mutex, RwLock};
+use tracing_test::traced_test;
 
 lazy_static! {
     static ref APP: Mutex<OnceLock<Arc<RwLock<PersonalCourseScheduleApplication>>>> =
@@ -34,15 +34,17 @@ async fn get_app() -> Result<Arc<RwLock<PersonalCourseScheduleApplication>>, Rus
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn schedule() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let info = app.schedule(*TARGET_YEAR, *TARGET_SEMESTER).await.unwrap();
-    println!("{:?}", info);
+    tracing::info!("{:?}", info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn no_schedule() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
@@ -51,5 +53,5 @@ async fn no_schedule() {
         info,
         RusaintError::ApplicationError(ApplicationError::NoScheduleInformation)
     ));
-    println!("{:?}", info);
+    tracing::info!("{:?}", info);
 }

--- a/packages/rusaint/tests/application/scholarships.rs
+++ b/packages/rusaint/tests/application/scholarships.rs
@@ -1,9 +1,10 @@
 use crate::get_session;
 use rusaint::application::USaintClientBuilder;
 use rusaint::application::scholarships::ScholarshipsApplication;
-use test_log::test;
+use tracing_test::traced_test;
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn scholarships() {
     let session = get_session().await.unwrap().clone();
     let mut app = USaintClientBuilder::new()
@@ -12,5 +13,5 @@ async fn scholarships() {
         .await
         .unwrap();
     let info = app.scholarships().await.unwrap();
-    println!("{:?}", info);
+    tracing::info!("{:?}", info);
 }

--- a/packages/rusaint/tests/application/student_information.rs
+++ b/packages/rusaint/tests/application/student_information.rs
@@ -55,7 +55,7 @@ async fn graduation() {
             },
         ))) => (),
         Err(err) => {
-            panic!("{:?}", err);
+            panic!("{err:?}");
         }
         Ok(_) => (),
     }

--- a/packages/rusaint/tests/application/student_information.rs
+++ b/packages/rusaint/tests/application/student_information.rs
@@ -6,8 +6,8 @@ use rusaint::{
     webdynpro::error::{ElementError, WebDynproError},
 };
 use std::sync::{Arc, OnceLock};
-use test_log::test;
 use tokio::sync::{Mutex, RwLock};
+use tracing_test::traced_test;
 
 lazy_static! {
     static ref APP: Mutex<OnceLock<Arc<RwLock<StudentInformationApplication>>>> =
@@ -32,15 +32,17 @@ async fn get_app() -> Result<Arc<RwLock<StudentInformationApplication>>, Rusaint
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn general() {
     let lock = get_app().await.unwrap();
     let app = lock.read().await;
     let student_info = app.general().unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn graduation() {
     let lock = get_app().await.unwrap();
     let app = lock.read().await;
@@ -57,69 +59,77 @@ async fn graduation() {
         }
         Ok(_) => (),
     }
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn qualifications() {
     let lock = get_app().await.unwrap();
     let app = lock.read().await;
     let student_info = app.qualifications();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn work() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.work().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn family() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.family().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn religion() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.religion().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn transfer() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.transfer().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn bank_account() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.bank_account().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn academic_record() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.academic_record().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn research_bank_account() {
     let lock = get_app().await.unwrap();
     let mut app = lock.write().await;
     let student_info = app.research_bank_account().await.unwrap();
-    println!("{:?}", student_info);
+    tracing::info!("{:?}", student_info);
 }

--- a/packages/rusaint/tests/tests.rs
+++ b/packages/rusaint/tests/tests.rs
@@ -27,10 +27,10 @@ lazy_static! {
 pub async fn get_session() -> Result<Arc<USaintSession>> {
     let session_file_path = std::env::var("SSO_SESSION_FILE").unwrap_or("session.json".to_string());
     let f = File::open(&session_file_path)
-        .map_err(|e| Error::msg(format!("Failed to open session file: {}", e)))?;
+        .map_err(|e| Error::msg(format!("Failed to open session file: {e}")))?;
     let reader = BufReader::new(f);
     let session: USaintSession = USaintSession::from_json(reader)
-        .map_err(|e| Error::msg(format!("Failed to parse session file: {}", e)))?;
+        .map_err(|e| Error::msg(format!("Failed to parse session file: {e}")))?;
     let session = Arc::new(session);
     Ok(session)
 }

--- a/packages/rusaint/tests/tests.rs
+++ b/packages/rusaint/tests/tests.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use rusaint::USaintSession;
 use rusaint::model::SemesterType;
 use std::{fs::File, io::BufReader, sync::Arc};
-use test_log::test;
+use tracing_test::traced_test;
 
 lazy_static! {
     pub(crate) static ref TARGET_YEAR: u32 = {
@@ -36,7 +36,8 @@ pub async fn get_session() -> Result<Arc<USaintSession>> {
 }
 
 #[cfg(test)]
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn test_session() {
     let _ = get_session().await.unwrap();
 }

--- a/packages/rusaint/tests/webdynpro/element/button.rs
+++ b/packages/rusaint/tests/webdynpro/element/button.rs
@@ -10,7 +10,7 @@ use rusaint::{
         error::WebDynproError,
     },
 };
-use test_log::test;
+use tracing_test::traced_test;
 
 impl<'a> EventTestSuite {
     define_elements! {
@@ -42,7 +42,8 @@ impl<'a> EventTestSuite {
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn test_button_events() {
     let lock = get_event_test_suite().await.unwrap();
     let mut suite = lock.write().await;

--- a/packages/rusaint/tests/webdynpro/element/link.rs
+++ b/packages/rusaint/tests/webdynpro/element/link.rs
@@ -7,7 +7,7 @@ use rusaint::{
         error::WebDynproError,
     },
 };
-use test_log::test;
+use tracing_test::traced_test;
 
 impl<'a> EventTestSuite {
     define_elements! {
@@ -39,7 +39,8 @@ impl<'a> EventTestSuite {
     }
 }
 
-#[test(tokio::test)]
+#[tokio::test]
+#[traced_test]
 async fn test_link_event() {
     let lock = get_event_test_suite().await.unwrap();
     let mut suite = lock.write().await;

--- a/packages/rusaint/tests/webdynpro/event/mod.rs
+++ b/packages/rusaint/tests/webdynpro/event/mod.rs
@@ -3,9 +3,10 @@ use rusaint::webdynpro::event::{
     ucf_parameters::{UcfAction, UcfParametersBuilder, UcfResponseData},
 };
 use std::collections::HashMap;
-use test_log::test;
+use tracing_test::traced_test;
 
 #[test]
+#[traced_test]
 fn event_serialize() {
     let mut parameters = HashMap::new();
     parameters.insert("Id".to_string(), "WD01A8".to_string());


### PR DESCRIPTION
# What's in this pull request
- `log` crate를 `tracing`으로 변경합니다.
- 이에 따라 `test_log` crate 도 `tracing_test`로 변경합니다.