### PR TITLE
[feat] `Link`, `Label`의 `Display` 구현 및 `textise` 리팩토링

### DIFF
--- a/packages/rusaint/src/webdynpro/element/complex/sap_table/from_sap_table.rs
+++ b/packages/rusaint/src/webdynpro/element/complex/sap_table/from_sap_table.rs
@@ -25,7 +25,9 @@ impl<'body> FromSapTable<'body> for Vec<Option<String>> {
         let vec = iter
             .map(|val| match val {
                 Ok(cell) => match cell.content() {
-                    Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.textise().ok()),
+                    Some(wrapper) => {
+                        Ok(ElementWrapper::from_def(&wrapper, parser)?.try_into().ok())
+                    }
                     None => Ok(None),
                 },
                 Err(err) => Err(err),
@@ -44,7 +46,7 @@ impl<'body> FromSapTable<'body> for Vec<String> {
         let iter = row.iter_value(parser);
         iter.map(|val| match val {
             Ok(cell) => match cell.content() {
-                Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.textise()?),
+                Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.try_into()?),
                 None => Err(ElementError::NoSuchContent {
                     element: "Cell Content".to_string(),
                     content: "No content provided".to_string(),
@@ -66,7 +68,7 @@ impl<'body> FromSapTable<'body> for Vec<(String, Option<String>)> {
         let header_string = header_iter
             .map(|val| match val {
                 Ok(cell) => match cell.content() {
-                    Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.textise()?),
+                    Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.try_into()?),
                     None => Ok(cell.id().to_owned()),
                 },
                 Err(err) => Err(err),
@@ -76,7 +78,9 @@ impl<'body> FromSapTable<'body> for Vec<(String, Option<String>)> {
         let row_string = iter
             .map(|val| match val {
                 Ok(cell) => match cell.content() {
-                    Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.textise().ok()),
+                    Some(wrapper) => {
+                        Ok(ElementWrapper::from_def(&wrapper, parser)?.try_into().ok())
+                    }
                     None => Ok(None),
                 },
                 Err(err) => Err(err),
@@ -100,7 +104,7 @@ impl<'body> FromSapTable<'body> for Vec<(String, String)> {
         let header_string = header_iter
             .map(|val| match val {
                 Ok(cell) => match cell.content() {
-                    Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.textise()?),
+                    Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?.try_into()?),
                     None => Ok(cell.id().to_owned()),
                 },
                 Err(err) => Err(err),
@@ -111,7 +115,7 @@ impl<'body> FromSapTable<'body> for Vec<(String, String)> {
             .map(|val| match val {
                 Ok(cell) => match cell.content() {
                     Some(wrapper) => Ok(ElementWrapper::from_def(&wrapper, parser)?
-                        .textise()
+                        .try_into()
                         .unwrap_or(wrapper.id().to_string())),
                     None => Ok("".to_owned()),
                 },

--- a/packages/rusaint/src/webdynpro/element/selection/check_box.rs
+++ b/packages/rusaint/src/webdynpro/element/selection/check_box.rs
@@ -72,3 +72,9 @@ impl<'a> CheckBox<'a> {
             .is_some_and(|str| str == "true")
     }
 }
+
+impl std::fmt::Display for CheckBox<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.checked())
+    }
+}

--- a/packages/rusaint/src/webdynpro/element/selection/combo_box.rs
+++ b/packages/rusaint/src/webdynpro/element/selection/combo_box.rs
@@ -129,3 +129,9 @@ impl<'a> ComboBox<'a> {
         self.element_ref.attr("value")
     }
 }
+
+impl std::fmt::Display for ComboBox<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value().unwrap_or_default())
+    }
+}

--- a/packages/rusaint/src/webdynpro/element/text/caption.rs
+++ b/packages/rusaint/src/webdynpro/element/text/caption.rs
@@ -71,3 +71,9 @@ impl<'a> Caption<'a> {
         })
     }
 }
+
+impl std::fmt::Display for Caption<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.text())
+    }
+}

--- a/packages/rusaint/src/webdynpro/element/text/input_field.rs
+++ b/packages/rusaint/src/webdynpro/element/text/input_field.rs
@@ -69,3 +69,9 @@ impl<'a> InputField<'a> {
         self.element_ref.attr("value")
     }
 }
+
+impl std::fmt::Display for InputField<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value().unwrap_or_default())
+    }
+}

--- a/packages/rusaint/src/webdynpro/element/text/label.rs
+++ b/packages/rusaint/src/webdynpro/element/text/label.rs
@@ -1,11 +1,17 @@
 use std::{borrow::Cow, cell::OnceCell};
 
-use crate::webdynpro::element::{macros::define_element_interactable, property::Visibility};
+use scraper::Node;
+
+use crate::webdynpro::element::{
+    Element as _, macros::define_element_interactable, property::Visibility,
+};
 
 // TODO: Implement additional events and data
 define_element_interactable! {
     #[doc = "버튼 등의 엘리먼트를 부연하는 라벨"]
-    Label<"L", "Label"> {},
+    Label<"L", "Label"> {
+        text: OnceCell<String>,
+    },
     #[doc = "[`Label`]의 정의"]
     LabelDef,
     #[doc = "[`Label`] 내부 데이터"]
@@ -44,6 +50,33 @@ impl<'a> Label<'a> {
             element_ref,
             lsdata: OnceCell::new(),
             lsevents: OnceCell::new(),
+            text: OnceCell::new(),
         }
+    }
+
+    /// 내부 텍스트를 반환합니다.
+    pub fn text(&self) -> &str {
+        self.text.get_or_init(|| {
+            self.element_ref()
+                .children()
+                .filter_map(|node| match node.value() {
+                    Node::Text(text) => Some(text.to_string()),
+                    Node::Element(elem) => {
+                        if elem.name() == "br" {
+                            Some("\n".to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                })
+                .collect::<String>()
+        })
+    }
+}
+
+impl std::fmt::Display for Label<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.text())
     }
 }

--- a/packages/rusaint/src/webdynpro/element/text/text_view.rs
+++ b/packages/rusaint/src/webdynpro/element/text/text_view.rs
@@ -60,3 +60,9 @@ impl<'a> TextView<'a> {
         })
     }
 }
+
+impl std::fmt::Display for TextView<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.text())
+    }
+}


### PR DESCRIPTION
# What's in this pull request
- 일반 string으로 표현될 수 있는 Element(`Link`, `Label`)에 대해 `Display` trait 을 구현합니다.
- `ElementWrapper::textise` 대신 `TryFrom<ElementWrapper> for String`을 구현하여 변환할 수 있도록 합니다.

고민: 가장 깔끔하게 하려면 모든 Element에 대해서 기본 Display trait을 구현하고 `ElementWrapper`에 대해 Display trait을 구현하는 것인데, 이렇게 되면

1. ElementWrapper가 각 element의 specialized display implementation을 통해 올바른 값이 표기되었는지 혹은 fallback method인 id 표시가 되었는지 caller 입장에서 알 수가 없음
2. Display가 T: ElementDefinition 에 대해 구현될 경우 [Autoref speicalization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md)을 통해 Display trait을 구현해야 하는데, 그렇게 되면 Display를 `T: ElementDefinition` 이 아닌 `&T: ElementDefinition` 에 대해 구현해야 하는 상황이 생김.

즉,

1. Element는 일반 Display 구현을 통해 Element 표기를 구현할 수 있어야 하고,
2. ElementWrapper에서는 Display 구현이 있는가 여부에 따라서 Ok/Err 를 반환할 수 있어야 함. => macro를 통해 자동으로

이 두개를 동시에 달성할 수 있는 인터페이스가 가능한가? 가 문제