### PR TITLE
[docs] README.md 설치 가이드 및 코드 예시 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ cargo add rusaint
 ## 예시
 
 ```rust
-use rusaint::application::course_grades::{CourseGrades, model::SemesterSummary};
-use rusaint::session::USaintSession;
-use futures::executor::block_on;
+use rusaint::application::course_grades::{CourseGradesApplication, model::{CourseType}};
+use rusaint::client::USaintClientBuilder;
+use rusaint::USaintSession;
+use rusaint::RusaintError;
+use std::sync::Arc;
 
 // 성적 정보를 출력하는 애플리케이션
-fn main() {
-    block_on(print_grades());
+#[tokio::main]
+async fn main() -> Result<(), RusaintError> {
+    print_grades().await
     /* SemesterSummary { year: 2022, semester: "2 학기", attempted_credits: 17.5, earned_credits: 17.5, pf_earned_credits: 0.5, grade_points_average: 4.5, grade_points_sum: 100.0, arithmetic_mean: 100.0, semester_rank: (1, 99), general_rank: (1, 99), academic_probation: false, consult: false, flunked: false }
      * ...
      */
@@ -47,8 +50,8 @@ fn main() {
 
 async fn print_grades() -> Result<(), RusaintError> {
     // USaintSession::from_token(id: &str, token: &str) 을 이용하여 비밀번호 없이 SSO 토큰으로 로그인 할 수 있음
-    let session = USaintSession::from_password("20211561", "password").await?;
-    let mut app = USaintClientBuilder::new().session(session).build_into::<CourseGrades>().await?;
+    let session = Arc::new(USaintSession::with_password("20211561", "password").await?);
+    let mut app = USaintClientBuilder::new().session(session).build_into::<CourseGradesApplication>().await?;
     let grades: Vec<SemesterGrade> = app.semesters(CourseType::Bachelor).await?;
     for grade in grades {
         println!("{:?}", grade);


### PR DESCRIPTION
## 개요

- 설치 문단에 `tokio` 런타임 관련 내용과, `tokio` 의존성 설치 명령어를 명시적으로 작성했어요. 

- 코드 예시를 변경했어요.

  - 누락되거나 작동하지 않던 모듈 불러오기를 수정했어요.
  - `block_on` 사용 대신 `tokio` 런타임에서 돌아가도록 수정했어요.
