### PR TITLE
[fix!] 오타난 필드명 수정 (calcuation->calculation)

### DIFF
--- a/packages/rusaint/src/application/graduation_requirements/model.rs
+++ b/packages/rusaint/src/application/graduation_requirements/model.rs
@@ -172,7 +172,7 @@ pub struct GraduationRequirement {
         rename(deserialize = "계산값"),
         deserialize_with = "deserialize_option_f32_string"
     )]
-    calcuation: Option<f32>,
+    calculation: Option<f32>,
     #[serde(
         rename(deserialize = "계산값 - 기준값"),
         deserialize_with = "deserialize_option_f32_string"
@@ -204,8 +204,8 @@ impl GraduationRequirement {
     }
 
     /// 계산값
-    pub fn calcuation(&self) -> Option<f32> {
-        self.calcuation
+    pub fn calculation(&self) -> Option<f32> {
+        self.calculation
     }
 
     /// 계산값 - 기준값


### PR DESCRIPTION
## 변경사항
- `GraduationRequirement`의 필드/게터 오타 calcuation을 calculation으로 수정